### PR TITLE
Addition of AirPurifierAccessory

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const RGBTWLightAccessory = require('./lib/RGBTWLightAccessory');
 const RGBTWOutletAccessory = require('./lib/RGBTWOutletAccessory');
 const TWLightAccessory = require('./lib/TWLightAccessory');
 const AirConditionerAccessory = require('./lib/AirConditionerAccessory');
+const AirPurifierAccessory = require('./lib/AirPurifierAccessory');
 const ConvectorAccessory = require('./lib/ConvectorAccessory');
 const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
 const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
@@ -31,6 +32,7 @@ const CLASS_DEF = {
     multioutlet: MultiOutletAccessory,
     custommultioutlet: CustomMultiOutletAccessory,
     airconditioner: AirConditionerAccessory,
+    airpurifier: AirPurifierAccessory,
     convector: ConvectorAccessory,
     garagedoor: GarageDoorAccessory,
     simpledimmer: SimpleDimmerAccessory,

--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -1,0 +1,425 @@
+const BaseAccessory = require('./BaseAccessory');
+
+const DP_SWITCH = '1';
+const DP_PM25 = '2';
+const DP_MODE = '3'
+const DP_FAN_SPEED = '4';
+const DP_LOCK_PHYSICAL_CONTROLS = '7';
+const DP_AIR_QUALITY = '21';
+
+/**
+ * Accessory for Air Purifiers, with an optional setting to also include Air Quality sensor details. 
+ * 
+ * 
+ * Extra settings:
+ * - fanSpeedSteps -  The number of fan speed stops that the device supports
+ * - nameAirQuality - Allows customisation of the air quality sensor name. Default is 'Air Quality'
+ * - showAirQuality - boolean for enabling the air quality service. 
+ * - noChildLock - boolean for disabling the child lock feature
+ * 
+ * Standard Air Purifier Data Points (dp):
+ * 1. switch
+ * 2. pm25
+ * 3. mode
+ * 4. fan_speed_enum
+ * 5. filter (Filter Usage)
+ * 6. anion
+ * 7. child_lock
+ * 8. light
+ * 9. uv (UV Disinfection)
+ * 10. wet (Humidify)
+ * 11. filter_reset (Reset Filter)
+ * 12. temp_indoor (Indoor Temp)
+ * 13. humidity (Indoor Humidity)
+ * 14. tvoc
+ * 15. eco2 (eCO2)
+ * 16. filter_days (Filter Days Left)
+ * 17. total_runtime
+ * 18. countdown_set
+ * 19. countdown_left
+ * 20. total_pm
+ * 21. air_quality
+ * 22. fault (Fault Alarm)
+ * 
+ * This accessory maps the DP ids to the following Characteristics:
+ * > 1 - Characteristic.ACTIVE
+ * > 3 - Characteristic.TargetAirPurifierState
+ * > 4 - Characteristic.RotationSpeed
+ * > 7 - Characteristic.LockPhysicalControls
+ * 
+ * TODO: 
+ * - Some of this implementation is very similar to AirConditionerAccessory. Likely some scope
+ *   for refactoring this. 
+ * 
+ * Notes:
+ * Testing on a Elechomes KJ200G-A3B-UK. This required in the configuration for the API version to
+ * be specified.
+ * "version": "3.3"
+ * 
+ * This device returned data point ids: 1, 2, 3, 4, 6, 7, 17, 20
+ * 
+ * 
+ */
+class AirPurifierAccessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.AIR_PURIFIER;
+    }
+
+    constructor(...props) {
+        super(...props);
+
+        const {Characteristic} = this.hap;
+
+
+        if (!this.device.context.noRotationSpeed) {
+            const fanSpeedSteps = (this.device.context.fanSpeedSteps && isFinite(this.device.context.fanSpeedSteps) && this.device.context.fanSpeedSteps > 0 && this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;
+            this._rotationSteps = [0];
+            this._rotationStops = {0: 0};
+            for (let i = 0; i++ < 100;) {
+                const _rotationStep = Math.floor(fanSpeedSteps * (i - 1) / 100) + 1;
+                this._rotationSteps.push(_rotationStep);
+                this._rotationStops[_rotationStep] = i;
+            }
+        }
+
+        this.airQualityLevels = [
+            [200, Characteristic.AirQuality.POOR],
+            [150, Characteristic.AirQuality.INFERIOR],
+            [100, Characteristic.AirQuality.FAIR],
+            [50, Characteristic.AirQuality.GOOD],
+            [0, Characteristic.AirQuality.EXCELLENT],
+        ];
+
+    }
+
+    /**
+     * Register the services that this accessory supports. 
+     */
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+        this.log.info('Device: %o', this.device.context);
+
+        /* Add the main air purifier */        
+        this.accessory.addService(Service.AirPurifier, this.device.context.name);
+
+        /* If configured to include air quality data, include that service too */
+        if (this.device.context.showAirQuality) {
+            const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
+            this.accessory.addService(Service.AirQualitySensor, nameAirQuality);
+        }
+
+        super._registerPlatformAccessory();
+    }
+
+    /**
+     * Register the Characteristics that this accessory supports. 
+     * @param {*} dps 
+     */
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+
+        const airPurifierService = this.accessory.getService(Service.AirPurifier);
+        this._checkServiceName(airPurifierService, this.device.context.name);
+
+        this.log.info('dps: %o', dps);
+
+        const characteristicActive = airPurifierService.getCharacteristic(Characteristic.Active)
+            .updateValue(this._getActive(dps[DP_SWITCH]))
+            .on('get', this.getActive.bind(this))
+            .on('set', this.setActive.bind(this));
+
+        const characteristicCurrentAirPurifierState = airPurifierService.getCharacteristic(Characteristic.CurrentAirPurifierState)
+            .updateValue(this._getCurrentAirPurifierState(dps[DP_SWITCH]))
+            .on('get', this.getCurrentAirPurifierState.bind(this));
+
+
+        const characteristicTargetAirPurifierState = airPurifierService.getCharacteristic(Characteristic.TargetAirPurifierState)
+            .updateValue(this._getTargetAirPurifierState(dps[DP_MODE]))
+            .on('get', this.getTargetAirPurifierState.bind(this))
+            .on('set', this.setTargetAirPurifierState.bind(this));
+
+        let characteristicLockPhysicalControls;
+        if (!this.device.context.noChildLock) {
+            characteristicLockPhysicalControls = airPurifierService.getCharacteristic(Characteristic.LockPhysicalControls)
+                .updateValue(this._getLockPhysicalControls(dps[DP_LOCK_PHYSICAL_CONTROLS]))
+                .on('get', this.getLockPhysicalControls.bind(this))
+                .on('set', this.setLockPhysicalControls.bind(this));
+        } else {
+            this._removeCharacteristic(service, Characteristic.LockPhysicalControls);
+        }
+
+        const characteristicRotationSpeed = airPurifierService.getCharacteristic(Characteristic.RotationSpeed)
+            .updateValue(this._getRotationSpeed(dps))
+            .on('get', this.getRotationSpeed.bind(this))
+            .on('set', this.setRotationSpeed.bind(this));
+
+        this.device.on('change', (changes, state) => {
+
+            if (changes.hasOwnProperty(DP_SWITCH)) {
+                /* On/Off state change */
+                const newActive = this._getActive(changes[DP_SWITCH]);
+                if (characteristicActive.value !== newActive) {
+                    characteristicActive.updateValue(newActive);
+
+                    characteristicCurrentAirPurifierState.updateValue(
+                        this._getCurrentAirPurifierState(changes[DP_SWITCH]));
+
+                    if (!changes.hasOwnProperty(DP_FAN_SPEED)) {
+                        characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
+                    }
+                }
+            }
+
+            if (changes.hasOwnProperty(DP_FAN_SPEED)) {
+                /* Fan speed change */
+                const newRotationSpeed = this._getRotationSpeed(state);
+                if (characteristicRotationSpeed.value !== newRotationSpeed) { 
+                    characteristicRotationSpeed.updateValue(newRotationSpeed);
+                }
+            }
+
+            if (characteristicLockPhysicalControls && changes.hasOwnProperty(DP_LOCK_PHYSICAL_CONTROLS)) {
+                /* Child Lock change */
+                const newLockPhysicalControls = this._getLockPhysicalControls(changes[DP_LOCK_PHYSICAL_CONTROLS]);
+                if (characteristicLockPhysicalControls.value !== newLockPhysicalControls) {
+                    characteristicLockPhysicalControls.updateValue(newLockPhysicalControls);
+                }
+            }
+
+            if (changes.hasOwnProperty(DP_MODE)) {
+                /* Change to the running mode */
+
+                const newTargetAirPurifierState = this._getTargetAirPurifierState(changes[DP_MODE]);
+                if (characteristicTargetAirPurifierState.value !== newTargetAirPurifierState) {
+                    characteristicTargetAirPurifierState.updateValue(newTargetAirPurifierState);
+                }
+            }
+        });
+
+        const airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
+        if (airQualitySensorService) {
+            const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
+            this._checkServiceName(airQualitySensorService, nameAirQuality);
+
+            const characteristicAirQuality = airQualitySensorService.getCharacteristic(Characteristic.AirQuality)
+                .updateValue(this._getAirQuality(dps))
+                .on('get', this.getAirQuality.bind(this));
+
+            const characteristicPM25Density = airQualitySensorService.getCharacteristic(Characteristic.PM2_5Density)
+                .updateValue(dps[DP_PM25])
+                .on('get', this.getPM25.bind(this));
+
+
+            this.device.on('change', (changes, state) => {
+
+                if (changes.hasOwnProperty(DP_PM25)) {
+                    const newPM25 = changes[DP_PM25];
+                    if (characteristicPM25Density.value !== newPM25) {
+                        characteristicPM25Density.updateValue(newPM25);
+                    }
+
+                    if (!changes.hasOwnProperty(DP_AIR_QUALITY)) {
+                        characteristicAirQuality.updateValue(this._getAirQuality(state));
+                    }
+
+
+                }
+            });
+
+
+            //TODO: rest of implementation
+        }
+    }
+
+    getActive(callback) {
+        this.getState(DP_SWITCH, (err, dp) => {
+            if (err) return callback(err);
+
+            callback(null, this._getActive(dp));
+        });
+    }
+
+    _getActive(dp) {
+        const {Characteristic} = this.hap;
+
+        return dp ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
+    }
+
+    setActive(value, callback) {
+        const {Characteristic} = this.hap;
+
+        switch (value) {
+            case Characteristic.Active.ACTIVE:
+                return this.setState(DP_SWITCH, true, callback);
+
+            case Characteristic.Active.INACTIVE:
+                return this.setState(DP_SWITCH, false, callback);
+        }
+
+        callback();
+    }
+
+    getAirQuality(callback) {
+        this.getState([DP_PM25], (err, dps) => {
+            if (err) return callback(err);
+
+            callback(null, this._getAirQuality(dps));
+        });
+    }
+
+    _getAirQuality(dps) {
+        /* TODO: Other DP values can be used for Air Quality */
+        if (dps[DP_PM25]) {
+
+            /* Loop through the air quality levels until a match is found */
+            for (var item of this.airQualityLevels) {
+                if (dps[DP_PM25] >= item[0]) {
+                    return item[1];
+                }
+            }
+
+        }
+
+        /* Default return value if nothing has already returned */
+        return 0;
+        
+    }
+
+    getCurrentAirPurifierState(callback) {
+        this.getState([DP_SWITCH], (err, dps) => {
+            if (err) return callback(err);
+
+            callback(null, this._getCurrentAirPurifierState(dps));
+        });
+    }
+
+    _getCurrentAirPurifierState(dp) {
+        const {Characteristic} = this.hap;
+
+        
+        /* There isn't really a direct mapping to this from the purifier, 
+         * so just using as inactive or purifying.
+         */
+
+        return dp ? Characteristic.CurrentAirPurifierState.PURIFYING_AIR : Characteristic.CurrentAirPurifierState.INACTIVE;
+    }
+
+    getLockPhysicalControls(callback) {
+        this.getState(DP_LOCK_PHYSICAL_CONTROLS, (err, dp) => {
+            if (err) return callback(err);
+
+            callback(null, this._getLockPhysicalControls(dp));
+        });
+    }
+
+    _getLockPhysicalControls(dp) {
+        const {Characteristic} = this.hap;
+
+        return dp ? Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED : Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
+    }
+
+    setLockPhysicalControls(value, callback) {
+        const {Characteristic} = this.hap;
+
+        switch (value) {
+            case Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED:
+                return this.setState(DP_LOCK_PHYSICAL_CONTROLS, true, callback);
+
+            case Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED:
+                return this.setState(DP_LOCK_PHYSICAL_CONTROLS, false, callback);
+        }
+
+        callback();
+    }
+
+    getPM25(callback) {
+        this.getState([DP_PM25], (err, dps) => {
+            if (err) return callback(err);
+
+            callback(null, dps);
+        });
+    }
+
+    getRotationSpeed(callback) {
+        this.getState([DP_SWITCH, DP_FAN_SPEED], (err, dps) => {
+            if (err) return callback(err);
+
+            callback(null, this._getRotationSpeed(dps));
+        });
+    }
+
+    _getRotationSpeed(dps) {
+        if (!dps[DP_SWITCH]) return 0;
+
+        if (this._hkRotationSpeed) {
+            const currntRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
+
+            return currntRotationSpeed === dps[DP_FAN_SPEED] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
+        }
+
+        return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
+    }
+
+    setRotationSpeed(value, callback) {
+        const {Characteristic} = this.hap;
+
+        if (value === 0) {
+            this.setActive(Characteristic.Active.INACTIVE, callback);
+        } else {
+            this._hkRotationSpeed = value;
+            this.setMultiState({DP_SWITCH: true, DP_FAN_SPEED: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);
+        }
+    }
+
+    getTargetAirPurifierState(callback) {
+        this.getState(DP_MODE, (err, dp) => {
+            if (err) return callback(err);
+
+            callback(null, this._getTargetAirPurifierState(dp));
+        });
+    }
+
+    _getTargetAirPurifierState(dp) {
+        const {Characteristic} = this.hap;
+
+
+        switch (dp) {
+            case 'manual':
+                return Characteristic.TargetAirPurifierState.MANUAL;
+            case 'sleep':
+                //TODO: Handle differently?
+            case 'auto':
+                return Characteristic.TargetAirPurifierState.AUTO;
+            default:
+                //TODO: Other codes possible?
+                return 9;
+        }
+    }
+
+    setTargetAirPurifierState(value, callback) {
+        const {Characteristic} = this.hap;
+
+        switch (value) {
+            case Characteristic.TargetAirPurifierState.MANUAL:
+                return this.setState(DP_MODE, 'manual', callback);
+
+            case Characteristic.TargetAirPurifierState.AUTO:
+                return this.setState(DP_MODE, 'auto', callback);
+
+            //TODO: Can we do anything about sleep?
+        }
+
+        callback();
+    }
+
+    convertRotationSpeedFromTuyaToHomeKit(value) {
+        return this._rotationStops[parseInt(value)];
+    }
+
+    convertRotationSpeedFromHomeKitToTuya(value) {
+        return this.device.context.fanSpeedSteps ? '' + this._rotationSteps[value] : this._rotationSteps[value];
+    }
+
+}
+
+module.exports = AirPurifierAccessory;

--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -13,8 +13,8 @@ const DP_AIR_QUALITY = '21';
  * 
  * Extra settings:
  * - fanSpeedSteps -  The number of fan speed stops that the device supports
- * - nameAirQuality - Allows customisation of the air quality sensor name. Default is 'Air Quality'
  * - showAirQuality - boolean for enabling the air quality service. 
+ * - nameAirQuality - Allows customisation of the air quality sensor name. Default is 'Air Quality'
  * - noChildLock - boolean for disabling the child lock feature
  * 
  * Standard Air Purifier Data Points (dp):
@@ -104,11 +104,18 @@ class AirPurifierAccessory extends BaseAccessory {
 
         /* If configured to include air quality data, include that service too */
         if (this.device.context.showAirQuality) {
-            const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
-            this.accessory.addService(Service.AirQualitySensor, nameAirQuality);
+            this._addAirQualityService();
         }
 
         super._registerPlatformAccessory();
+    }
+
+    _addAirQualityService() {
+        const {Service} = this.hap;
+
+        const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
+        this.log.info('Adding air quality sensor: %s', nameAirQuality);
+        this.accessory.addService(Service.AirQualitySensor, nameAirQuality);
     }
 
     /**
@@ -118,6 +125,7 @@ class AirPurifierAccessory extends BaseAccessory {
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
 
+        /* Air purifier service characteristics */
         const airPurifierService = this.accessory.getService(Service.AirPurifier);
         this._checkServiceName(airPurifierService, this.device.context.name);
 
@@ -153,7 +161,35 @@ class AirPurifierAccessory extends BaseAccessory {
             .on('get', this.getRotationSpeed.bind(this))
             .on('set', this.setRotationSpeed.bind(this));
 
+        /* Air quality sensor characteristics */
+        let airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
+        let characteristicAirQuality;
+        let characteristicPM25Density;
+
+        /* If configured to include air quality data, and it was not already registered, register it */
+        if (!airQualitySensorService && this.device.context.showAirQuality) {
+            this._addAirQualityService();
+            airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
+        }
+
+        if (airQualitySensorService) {
+            const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
+            this._checkServiceName(airQualitySensorService, nameAirQuality);
+
+            characteristicAirQuality = airQualitySensorService.getCharacteristic(Characteristic.AirQuality)
+                .updateValue(this._getAirQuality(dps))
+                .on('get', this.getAirQuality.bind(this));
+
+            characteristicPM25Density = airQualitySensorService.getCharacteristic(Characteristic.PM2_5Density)
+                .updateValue(dps[DP_PM25])
+                .on('get', this.getPM25.bind(this));
+        }
+
+        /* Listen for changes */
         this.device.on('change', (changes, state) => {
+
+            this.log.info('Change: %o', changes)
+            this.log.info('State: %o', state);
 
             if (changes.hasOwnProperty(DP_SWITCH)) {
                 /* On/Off state change */
@@ -194,41 +230,20 @@ class AirPurifierAccessory extends BaseAccessory {
                     characteristicTargetAirPurifierState.updateValue(newTargetAirPurifierState);
                 }
             }
+
+            if (airQualitySensorService && changes.hasOwnProperty(DP_PM25)) {
+                const newPM25 = changes[DP_PM25];
+                if (characteristicPM25Density.value !== newPM25) {
+                    characteristicPM25Density.updateValue(newPM25);
+                }
+
+                if (!changes.hasOwnProperty(DP_AIR_QUALITY)) {
+                    characteristicAirQuality.updateValue(this._getAirQuality(state));
+                }
+            }
         });
 
-        const airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
-        if (airQualitySensorService) {
-            const nameAirQuality = this.device.context.nameAirQuality || 'Air Quality';
-            this._checkServiceName(airQualitySensorService, nameAirQuality);
-
-            const characteristicAirQuality = airQualitySensorService.getCharacteristic(Characteristic.AirQuality)
-                .updateValue(this._getAirQuality(dps))
-                .on('get', this.getAirQuality.bind(this));
-
-            const characteristicPM25Density = airQualitySensorService.getCharacteristic(Characteristic.PM2_5Density)
-                .updateValue(dps[DP_PM25])
-                .on('get', this.getPM25.bind(this));
-
-
-            this.device.on('change', (changes, state) => {
-
-                if (changes.hasOwnProperty(DP_PM25)) {
-                    const newPM25 = changes[DP_PM25];
-                    if (characteristicPM25Density.value !== newPM25) {
-                        characteristicPM25Density.updateValue(newPM25);
-                    }
-
-                    if (!changes.hasOwnProperty(DP_AIR_QUALITY)) {
-                        characteristicAirQuality.updateValue(this._getAirQuality(state));
-                    }
-
-
-                }
-            });
-
-
-            //TODO: rest of implementation
-        }
+        
     }
 
     getActive(callback) {
@@ -384,11 +399,11 @@ class AirPurifierAccessory extends BaseAccessory {
 
 
         switch (dp) {
-            case 'manual':
+            case 'Manual':
                 return Characteristic.TargetAirPurifierState.MANUAL;
-            case 'sleep':
+            case 'Sleep':
                 //TODO: Handle differently?
-            case 'auto':
+            case 'Auto':
                 return Characteristic.TargetAirPurifierState.AUTO;
             default:
                 //TODO: Other codes possible?
@@ -401,10 +416,10 @@ class AirPurifierAccessory extends BaseAccessory {
 
         switch (value) {
             case Characteristic.TargetAirPurifierState.MANUAL:
-                return this.setState(DP_MODE, 'manual', callback);
+                return this.setState(DP_MODE, 'Manual', callback);
 
             case Characteristic.TargetAirPurifierState.AUTO:
-                return this.setState(DP_MODE, 'auto', callback);
+                return this.setState(DP_MODE, 'Auto', callback);
 
             //TODO: Can we do anything about sleep?
         }

--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -7,15 +7,20 @@ const DP_FAN_SPEED = '4';
 const DP_LOCK_PHYSICAL_CONTROLS = '7';
 const DP_AIR_QUALITY = '21';
 
+const STATE_OTHER = 9;
+
 /**
  * Accessory for Air Purifiers, with an optional setting to also include Air Quality sensor details. 
  * 
  * 
  * Extra settings:
- * - fanSpeedSteps -  The number of fan speed stops that the device supports
- * - showAirQuality - boolean for enabling the air quality service. 
- * - nameAirQuality - Allows customisation of the air quality sensor name. Default is 'Air Quality'
- * - noChildLock - boolean for disabling the child lock feature
+ * - noRotationSpeed - boolean which, if set to true, will disable the fan speed control
+ * - fanSpeedSteps -   The number of fan speed stops that the device supports. The default is 100.
+ * - showAirQuality -  boolean for enabling the air quality service. The default is false, which
+ *                     will not include air quality values. 
+ * - nameAirQuality -  Allows customisation of the air quality sensor name. Default is 'Air Quality'
+ * - noChildLock -     boolean for disabling the child lock feature. The default is false, which
+ *                     will enable the child lock feature
  * 
  * Standard Air Purifier Data Points (dp):
  * 1. switch
@@ -42,21 +47,38 @@ const DP_AIR_QUALITY = '21';
  * 22. fault (Fault Alarm)
  * 
  * This accessory maps the DP ids to the following Characteristics:
- * > 1 - Characteristic.ACTIVE
- * > 3 - Characteristic.TargetAirPurifierState
- * > 4 - Characteristic.RotationSpeed
- * > 7 - Characteristic.LockPhysicalControls
+ * - 1 - Characteristic.ACTIVE / Characteristic.CurrentAirPurifierState
+ * - 2 - Characteristic.PM2_5Density / Characteristic.AirQuality
+ * - 3 - Characteristic.TargetAirPurifierState
+ * - 4 - Characteristic.RotationSpeed
+ * - 7 - Characteristic.LockPhysicalControls
  * 
- * TODO: 
+ * Future Enhancements:
  * - Some of this implementation is very similar to AirConditionerAccessory. Likely some scope
  *   for refactoring this. 
+ * - Some air purifiers support more of the standard data points than the original test device, 
+ *   so additional services like Filter Maintenance could be added
+ *   https://developers.homebridge.io/#/service/FilterMaintenance
+ * - _getAirQuality currenly calculates a value based on the pm25 value. I do not have a device 
+ *   that supports the air_quality data point to see what the return type would be
  * 
  * Notes:
- * Testing on a Elechomes KJ200G-A3B-UK. This required in the configuration for the API version to
- * be specified.
- * "version": "3.3"
+ * Initial testing was performed on a Elechomes KJ200G-A3B-UK. This required in the configuration for the API version to
+ * be specified. This device returned data point ids: 1, 2, 3, 4, 6, 7, 17, 20
  * 
- * This device returned data point ids: 1, 2, 3, 4, 6, 7, 17, 20
+ * Sample configuration for KJ200G-A3B-UK:
+ * {
+ *    "name": "Living Room Air Purifier",
+ *    "type": "AirPurifier",
+ *    "manufacturer": "Elechomes",
+ *    "model": "KJ200G-A3B-UK",
+ *    "id": "REDACTED",
+ *    "key": "REDACTED",
+ *    "ip": "192.168.99.50",
+ *    "version": "3.3",
+ *    "fanSpeedSteps": 3,
+ *    "showAirQuality": true
+ * }
  * 
  * 
  */
@@ -72,9 +94,16 @@ class AirPurifierAccessory extends BaseAccessory {
 
 
         if (!this.device.context.noRotationSpeed) {
-            const fanSpeedSteps = (this.device.context.fanSpeedSteps && isFinite(this.device.context.fanSpeedSteps) && this.device.context.fanSpeedSteps > 0 && this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;
+
+            const fanSpeedSteps = (
+                this.device.context.fanSpeedSteps && 
+                isFinite(this.device.context.fanSpeedSteps) && 
+                this.device.context.fanSpeedSteps > 0 && 
+                this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;
+
             this._rotationSteps = [0];
             this._rotationStops = {0: 0};
+
             for (let i = 0; i++ < 100;) {
                 const _rotationStep = Math.floor(fanSpeedSteps * (i - 1) / 100) + 1;
                 this._rotationSteps.push(_rotationStep);
@@ -97,7 +126,6 @@ class AirPurifierAccessory extends BaseAccessory {
      */
     _registerPlatformAccessory() {
         const {Service} = this.hap;
-        this.log.info('Device: %o', this.device.context);
 
         /* Add the main air purifier */        
         this.accessory.addService(Service.AirPurifier, this.device.context.name);
@@ -110,6 +138,12 @@ class AirPurifierAccessory extends BaseAccessory {
         super._registerPlatformAccessory();
     }
 
+    /**
+     * Method to add the AirQualitySensor service to the accessory. 
+     * 
+     * This is seperate as it may be called after the initial _registerPlatformAccessory call,
+     * if the configuration is updated after the device is first added. 
+     */
     _addAirQualityService() {
         const {Service} = this.hap;
 
@@ -129,7 +163,7 @@ class AirPurifierAccessory extends BaseAccessory {
         const airPurifierService = this.accessory.getService(Service.AirPurifier);
         this._checkServiceName(airPurifierService, this.device.context.name);
 
-        this.log.info('dps: %o', dps);
+        this.log.debug('_registerCharacteristics dps: %o', dps);
 
         const characteristicActive = airPurifierService.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[DP_SWITCH]))
@@ -166,10 +200,15 @@ class AirPurifierAccessory extends BaseAccessory {
         let characteristicAirQuality;
         let characteristicPM25Density;
 
-        /* If configured to include air quality data, and it was not already registered, register it */
+        /* Ensure the air quality sensor service existance aligns with the configuration.  
+         * If configured to include air quality data, and the service was not already registered, register it.
+         * If configured to not include it, but the service this there, remove it 
+         */
         if (!airQualitySensorService && this.device.context.showAirQuality) {
             this._addAirQualityService();
             airQualitySensorService = this.accessory.getService(Service.AirQualitySensor);
+        } else if (airQualitySensorService && !this.device.context.showAirQuality) {
+            this.accessory.removeService(airQualitySensorService);
         }
 
         if (airQualitySensorService) {
@@ -188,8 +227,7 @@ class AirPurifierAccessory extends BaseAccessory {
         /* Listen for changes */
         this.device.on('change', (changes, state) => {
 
-            this.log.info('Change: %o', changes)
-            this.log.info('State: %o', state);
+            this.log.debug('Changes: %o, State: %o', changes, state);
 
             if (changes.hasOwnProperty(DP_SWITCH)) {
                 /* On/Off state change */
@@ -203,6 +241,10 @@ class AirPurifierAccessory extends BaseAccessory {
                     if (!changes.hasOwnProperty(DP_FAN_SPEED)) {
                         characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
                     }
+                    if (!changes.hasOwnProperty(DP_MODE)) {
+                        characteristicTargetAirPurifierState.updateValue(
+                            this._getTargetAirPurifierState(state[DP_MODE]));
+                    }
                 }
             }
 
@@ -211,6 +253,11 @@ class AirPurifierAccessory extends BaseAccessory {
                 const newRotationSpeed = this._getRotationSpeed(state);
                 if (characteristicRotationSpeed.value !== newRotationSpeed) { 
                     characteristicRotationSpeed.updateValue(newRotationSpeed);
+                }
+
+                if (!changes.hasOwnProperty(DP_MODE)) {
+                    characteristicTargetAirPurifierState.updateValue(
+                        this._getTargetAirPurifierState(state[DP_MODE]));
                 }
             }
 
@@ -232,6 +279,7 @@ class AirPurifierAccessory extends BaseAccessory {
             }
 
             if (airQualitySensorService && changes.hasOwnProperty(DP_PM25)) {
+                /* Change to the air quality */
                 const newPM25 = changes[DP_PM25];
                 if (characteristicPM25Density.value !== newPM25) {
                     characteristicPM25Density.updateValue(newPM25);
@@ -241,14 +289,14 @@ class AirPurifierAccessory extends BaseAccessory {
                     characteristicAirQuality.updateValue(this._getAirQuality(state));
                 }
             }
-        });
-
-        
+        });        
     }
 
     getActive(callback) {
         this.getState(DP_SWITCH, (err, dp) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, this._getActive(dp));
         });
@@ -276,7 +324,9 @@ class AirPurifierAccessory extends BaseAccessory {
 
     getAirQuality(callback) {
         this.getState([DP_PM25], (err, dps) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, this._getAirQuality(dps));
         });
@@ -321,7 +371,9 @@ class AirPurifierAccessory extends BaseAccessory {
 
     getLockPhysicalControls(callback) {
         this.getState(DP_LOCK_PHYSICAL_CONTROLS, (err, dp) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, this._getLockPhysicalControls(dp));
         });
@@ -349,7 +401,9 @@ class AirPurifierAccessory extends BaseAccessory {
 
     getPM25(callback) {
         this.getState([DP_PM25], (err, dps) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, dps);
         });
@@ -357,16 +411,18 @@ class AirPurifierAccessory extends BaseAccessory {
 
     getRotationSpeed(callback) {
         this.getState([DP_SWITCH, DP_FAN_SPEED], (err, dps) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, this._getRotationSpeed(dps));
         });
     }
 
     _getRotationSpeed(dps) {
-        if (!dps[DP_SWITCH]) return 0;
-
-        if (this._hkRotationSpeed) {
+        if (!dps[DP_SWITCH]) {
+            return 0;
+        } else if (this._hkRotationSpeed) {
             const currntRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
 
             return currntRotationSpeed === dps[DP_FAN_SPEED] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
@@ -388,7 +444,9 @@ class AirPurifierAccessory extends BaseAccessory {
 
     getTargetAirPurifierState(callback) {
         this.getState(DP_MODE, (err, dp) => {
-            if (err) return callback(err);
+            if (err) {
+                return callback(err);
+            }
 
             callback(null, this._getTargetAirPurifierState(dp));
         });
@@ -402,12 +460,12 @@ class AirPurifierAccessory extends BaseAccessory {
             case 'Manual':
                 return Characteristic.TargetAirPurifierState.MANUAL;
             case 'Sleep':
-                //TODO: Handle differently?
+                //TODO: Handle differently than passing through?
             case 'Auto':
                 return Characteristic.TargetAirPurifierState.AUTO;
             default:
-                //TODO: Other codes possible?
-                return 9;
+                this.log.warn('Unhandled getTargetAirPurifierState value: %s', dp);
+                return STATE_OTHER;
         }
     }
 
@@ -421,7 +479,9 @@ class AirPurifierAccessory extends BaseAccessory {
             case Characteristic.TargetAirPurifierState.AUTO:
                 return this.setState(DP_MODE, 'Auto', callback);
 
-            //TODO: Can we do anything about sleep?
+            default:
+                //TODO: Can we do anything about Sleep?
+                this.log.warn('Unhandled setTargetAirPurifierState value: %s', value);
         }
 
         callback();


### PR DESCRIPTION
Addition of a new AirPurifier device type. Also includes an optional setting to include Air Quality sensor details. The new `AirPurifierAccessory.js` file contains a lot of this detail as comments, and enhancements that could be made. 

Settings supported:
* noRotationSpeed - boolean which, if set to true, will disable the fan speed control
* fanSpeedSteps - The number of fan speed stops that the device supports. The default is 100.
* showAirQuality - boolean for enabling the air quality service. The default is false, which will not include air quality values. 
* nameAirQuality - Allows customisation of the air quality sensor name. Default is 'Air Quality'
* noChildLock - boolean for disabling the child lock feature. The default is false, which will enable the child lock feature

This accessory maps the DP ids to the following Characteristics:
* 1 (switch) - Characteristic.ACTIVE / Characteristic.CurrentAirPurifierState
* 2 (pm25) - Characteristic.PM2_5Density / Characteristic.AirQuality
* 3 (mode) - Characteristic.TargetAirPurifierState
* 4 (fan_speed_enum) - Characteristic.RotationSpeed
* 7 (child_lock) - Characteristic.LockPhysicalControls

Tested using a [Elechomes KJ200G-A3B-UK](https://www.amazon.co.uk/gp/product/B082FW4W6J/), so the feature support has pretty much been tailored around what I could test. This required to use version 3.3 of the API. 

 Sample configuration for KJ200G-A3B-UK:
```
 {
    "name": "Living Room Air Purifier",
    "type": "AirPurifier",
    "manufacturer": "Elechomes",
    "model": "KJ200G-A3B-UK",
    "id": "REDACTED",
    "key": "REDACTED",
    "ip": "192.168.99.50",
    "version": "3.3",
    "fanSpeedSteps": 3,
    "showAirQuality": true
 }
```