### PR TITLE
initial support for breville smart connect air purifier

### DIFF
--- a/lib/AirPurifierAccessory.js
+++ b/lib/AirPurifierAccessory.js
@@ -5,23 +5,23 @@ const DP_PM25 = '2';
 const DP_MODE = '3'
 const DP_FAN_SPEED = '4';
 const DP_LOCK_PHYSICAL_CONTROLS = '7';
-const DP_AIR_QUALITY = '21';
+const DP_AIR_QUALITY = '22';
 
 const STATE_OTHER = 9;
 
 /**
- * Accessory for Air Purifiers, with an optional setting to also include Air Quality sensor details. 
- * 
- * 
+ * Accessory for Air Purifiers, with an optional setting to also include Air Quality sensor details.
+ *
+ *
  * Extra settings:
  * - noRotationSpeed - boolean which, if set to true, will disable the fan speed control
  * - fanSpeedSteps -   The number of fan speed stops that the device supports. The default is 100.
  * - showAirQuality -  boolean for enabling the air quality service. The default is false, which
- *                     will not include air quality values. 
+ *                     will not include air quality values.
  * - nameAirQuality -  Allows customisation of the air quality sensor name. Default is 'Air Quality'
  * - noChildLock -     boolean for disabling the child lock feature. The default is false, which
  *                     will enable the child lock feature
- * 
+ *
  * Standard Air Purifier Data Points (dp):
  * 1. switch
  * 2. pm25
@@ -40,32 +40,36 @@ const STATE_OTHER = 9;
  * 15. eco2 (eCO2)
  * 16. filter_days (Filter Days Left)
  * 17. total_runtime
- * 18. countdown_set
+ * 18. countdown_sete
  * 19. countdown_left
  * 20. total_pm
- * 21. air_quality
- * 22. fault (Fault Alarm)
- * 
+ * 21. ???
+ * 22. air_quality (verified on Breville Smart Air Connect)
+ * ???. fault (Fault Alarm)
+ *
  * This accessory maps the DP ids to the following Characteristics:
  * - 1 - Characteristic.ACTIVE / Characteristic.CurrentAirPurifierState
  * - 2 - Characteristic.PM2_5Density / Characteristic.AirQuality
  * - 3 - Characteristic.TargetAirPurifierState
  * - 4 - Characteristic.RotationSpeed
  * - 7 - Characteristic.LockPhysicalControls
- * 
+ *
+ * Device compatability:
+ * - Some devices, like the Breville Smart Air Connect, return and expect text rather than numeric Characteristics. To handle these properly, ensure that you set the 'manufacturer' configuration to 'Breville'.
+ *
  * Future Enhancements:
  * - Some of this implementation is very similar to AirConditionerAccessory. Likely some scope
- *   for refactoring this. 
- * - Some air purifiers support more of the standard data points than the original test device, 
+ *   for refactoring this.
+ * - Some air purifiers support more of the standard data points than the original test device,
  *   so additional services like Filter Maintenance could be added
  *   https://developers.homebridge.io/#/service/FilterMaintenance
- * - _getAirQuality currenly calculates a value based on the pm25 value. I do not have a device 
+ * - _getAirQuality currenly calculates a value based on the pm25 value. I do not have a device
  *   that supports the air_quality data point to see what the return type would be
- * 
+ *
  * Notes:
  * Initial testing was performed on a Elechomes KJ200G-A3B-UK. This required in the configuration for the API version to
  * be specified. This device returned data point ids: 1, 2, 3, 4, 6, 7, 17, 20
- * 
+ *
  * Sample configuration for KJ200G-A3B-UK:
  * {
  *    "name": "Living Room Air Purifier",
@@ -79,8 +83,8 @@ const STATE_OTHER = 9;
  *    "fanSpeedSteps": 3,
  *    "showAirQuality": true
  * }
- * 
- * 
+ *
+ *
  */
 class AirPurifierAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -96,18 +100,31 @@ class AirPurifierAccessory extends BaseAccessory {
         if (!this.device.context.noRotationSpeed) {
 
             const fanSpeedSteps = (
-                this.device.context.fanSpeedSteps && 
-                isFinite(this.device.context.fanSpeedSteps) && 
-                this.device.context.fanSpeedSteps > 0 && 
+                this.device.context.fanSpeedSteps &&
+                isFinite(this.device.context.fanSpeedSteps) &&
+                this.device.context.fanSpeedSteps > 0 &&
                 this.device.context.fanSpeedSteps < 100) ? this.device.context.fanSpeedSteps : 100;
 
-            this._rotationSteps = [0];
-            this._rotationStops = {0: 0};
 
-            for (let i = 0; i++ < 100;) {
-                const _rotationStep = Math.floor(fanSpeedSteps * (i - 1) / 100) + 1;
-                this._rotationSteps.push(_rotationStep);
-                this._rotationStops[_rotationStep] = i;
+            let _fanSpeedLabels = {};
+
+            // Special handling for particular devices //
+            switch (this.device.context.manufacturer) {
+                case 'Breville':
+                    _fanSpeedLabels = {0: 'off', 1: 'low', 2: 'mid', 3: 'high', 4: 'turbo'};
+                    this._rotationSteps = [...Array(5).keys()];
+                    break;
+                default: // Just use numeric values
+                    this._rotationSteps = [...Array(fanSpeedSteps).keys()];
+                    for (let i = 0; i <= fanSpeedSteps; i++) {
+                      _fanSpeedLabels[i] = i;
+                    }
+            }
+
+            this._rotationStops = {0: _fanSpeedLabels[0]};
+            for (let i = 0; i < 100; i++) {
+                const _rotationStep = Math.floor(fanSpeedSteps * i / 100);
+                this._rotationStops[i+1] = _fanSpeedLabels[_rotationStep];
             }
         }
 
@@ -119,15 +136,21 @@ class AirPurifierAccessory extends BaseAccessory {
             [0, Characteristic.AirQuality.EXCELLENT],
         ];
 
+        this.cmdAuto = 'AUTO';
+        if (this.device.context.cmdAuto) {
+            if (/^a[a-z]+$/i.test(this.device.context.cmdAuto)) this.cmdAuto = ('' + this.device.context.cmdAuto).trim();
+            else throw new Error('The cmdAuto doesn\'t appear to be valid: ' + this.device.context.cmdAuto);
+        }
+
     }
 
     /**
-     * Register the services that this accessory supports. 
+     * Register the services that this accessory supports.
      */
     _registerPlatformAccessory() {
         const {Service} = this.hap;
 
-        /* Add the main air purifier */        
+        /* Add the main air purifier */
         this.accessory.addService(Service.AirPurifier, this.device.context.name);
 
         /* If configured to include air quality data, include that service too */
@@ -139,10 +162,10 @@ class AirPurifierAccessory extends BaseAccessory {
     }
 
     /**
-     * Method to add the AirQualitySensor service to the accessory. 
-     * 
+     * Method to add the AirQualitySensor service to the accessory.
+     *
      * This is seperate as it may be called after the initial _registerPlatformAccessory call,
-     * if the configuration is updated after the device is first added. 
+     * if the configuration is updated after the device is first added.
      */
     _addAirQualityService() {
         const {Service} = this.hap;
@@ -153,8 +176,8 @@ class AirPurifierAccessory extends BaseAccessory {
     }
 
     /**
-     * Register the Characteristics that this accessory supports. 
-     * @param {*} dps 
+     * Register the Characteristics that this accessory supports.
+     * @param {*} dps
      */
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
@@ -200,9 +223,9 @@ class AirPurifierAccessory extends BaseAccessory {
         let characteristicAirQuality;
         let characteristicPM25Density;
 
-        /* Ensure the air quality sensor service existance aligns with the configuration.  
+        /* Ensure the air quality sensor service existance aligns with the configuration.
          * If configured to include air quality data, and the service was not already registered, register it.
-         * If configured to not include it, but the service this there, remove it 
+         * If configured to not include it, but the service this there, remove it
          */
         if (!airQualitySensorService && this.device.context.showAirQuality) {
             this._addAirQualityService();
@@ -251,7 +274,7 @@ class AirPurifierAccessory extends BaseAccessory {
             if (changes.hasOwnProperty(DP_FAN_SPEED)) {
                 /* Fan speed change */
                 const newRotationSpeed = this._getRotationSpeed(state);
-                if (characteristicRotationSpeed.value !== newRotationSpeed) { 
+                if (characteristicRotationSpeed.value !== newRotationSpeed) {
                     characteristicRotationSpeed.updateValue(newRotationSpeed);
                 }
 
@@ -289,7 +312,7 @@ class AirPurifierAccessory extends BaseAccessory {
                     characteristicAirQuality.updateValue(this._getAirQuality(state));
                 }
             }
-        });        
+        });
     }
 
     getActive(callback) {
@@ -333,21 +356,41 @@ class AirPurifierAccessory extends BaseAccessory {
     }
 
     _getAirQuality(dps) {
+        const {Characteristic} = this.hap;
         /* TODO: Other DP values can be used for Air Quality */
-        if (dps[DP_PM25]) {
-
-            /* Loop through the air quality levels until a match is found */
-            for (var item of this.airQualityLevels) {
-                if (dps[DP_PM25] >= item[0]) {
-                    return item[1];
+        switch (this.device.context.manufacturer) {
+            case 'Breville':
+                if (dps[DP_AIR_QUALITY]) {
+                  switch (dps[DP_AIR_QUALITY]) {
+                      case 'poor':
+                          return Characteristic.AirQuality.POOR
+                      case 'good':
+                          return Characteristic.AirQuality.GOOD
+                      case 'great':
+                          return Characteristic.AirQuality.EXCELLENT
+                      default:
+                          this.log.warn('Unhandled _getAirQuality value: %s', dps[DP_AIR_QUALITY]);
+                          return Characteristic.AirQuality.UNKNOWN
+                  }
                 }
-            }
+                break;
+            default:
 
+              if (dps[DP_PM25]) {
+
+                  /* Loop through the air quality levels until a match is found */
+                  for (var item of this.airQualityLevels) {
+                      if (dps[DP_PM25] >= item[0]) {
+                          return item[1];
+                      }
+                  }
+
+              }
         }
 
         /* Default return value if nothing has already returned */
         return 0;
-        
+
     }
 
     getCurrentAirPurifierState(callback) {
@@ -361,8 +404,8 @@ class AirPurifierAccessory extends BaseAccessory {
     _getCurrentAirPurifierState(dp) {
         const {Characteristic} = this.hap;
 
-        
-        /* There isn't really a direct mapping to this from the purifier, 
+
+        /* There isn't really a direct mapping to this from the purifier,
          * so just using as inactive or purifying.
          */
 
@@ -425,7 +468,7 @@ class AirPurifierAccessory extends BaseAccessory {
         } else if (this._hkRotationSpeed) {
             const currntRotationSpeed = this.convertRotationSpeedFromHomeKitToTuya(this._hkRotationSpeed);
 
-            return currntRotationSpeed === dps[DP_FAN_SPEED] ? this._hkRotationSpeed : this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
+            return currntRotationSpeed === dps[DP_FAN_SPEED] ? this._hkRotationSpeed : this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
         }
 
         return this._hkRotationSpeed = this.convertRotationSpeedFromTuyaToHomeKit(dps[DP_FAN_SPEED]);
@@ -438,7 +481,11 @@ class AirPurifierAccessory extends BaseAccessory {
             this.setActive(Characteristic.Active.INACTIVE, callback);
         } else {
             this._hkRotationSpeed = value;
-            this.setMultiState({DP_SWITCH: true, DP_FAN_SPEED: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);
+            // This code was only sending the first code, not the second...
+            //const newState = {DP_SWITCH: true, DP_FAN_SPEED: this.convertRotationSpeedFromHomeKitToTuya(value)};
+            //this.log.debug('setRotationSpeed value: %s. State: %s', value, newState);
+            //return this.setMultiState(newState, callback);
+            return this.setState(DP_FAN_SPEED, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
         }
     }
 
@@ -455,12 +502,13 @@ class AirPurifierAccessory extends BaseAccessory {
     _getTargetAirPurifierState(dp) {
         const {Characteristic} = this.hap;
 
-
         switch (dp) {
+            case 'manual':
             case 'Manual':
                 return Characteristic.TargetAirPurifierState.MANUAL;
             case 'Sleep':
                 //TODO: Handle differently than passing through?
+            case 'auto':
             case 'Auto':
                 return Characteristic.TargetAirPurifierState.AUTO;
             default:
@@ -471,14 +519,20 @@ class AirPurifierAccessory extends BaseAccessory {
 
     setTargetAirPurifierState(value, callback) {
         const {Characteristic} = this.hap;
-
         switch (value) {
             case Characteristic.TargetAirPurifierState.MANUAL:
-                return this.setState(DP_MODE, 'Manual', callback);
+                if (this.device.context.manufacturer == 'Breville') {
+                    return this.setState(DP_MODE, 'manual', callback);
+                } else {
+                    return this.setState(DP_MODE, 'Manual', callback);
+                }
 
             case Characteristic.TargetAirPurifierState.AUTO:
-                return this.setState(DP_MODE, 'Auto', callback);
-
+                if (this.device.context.manufacturer == 'Breville') {
+                    return this.setState(DP_MODE, 'auto', callback);
+                } else {
+                    return this.setState(DP_MODE, 'Auto', callback);
+                }
             default:
                 //TODO: Can we do anything about Sleep?
                 this.log.warn('Unhandled setTargetAirPurifierState value: %s', value);
@@ -487,12 +541,18 @@ class AirPurifierAccessory extends BaseAccessory {
         callback();
     }
 
-    convertRotationSpeedFromTuyaToHomeKit(value) {
-        return this._rotationStops[parseInt(value)];
+    getKeyByValue(object, value) {
+      return Object.keys(object).find(key => object[key] === value);
     }
 
     convertRotationSpeedFromHomeKitToTuya(value) {
-        return this.device.context.fanSpeedSteps ? '' + this._rotationSteps[value] : this._rotationSteps[value];
+        this.log.debug('convertRotationSpeedFromHomeKitToTuya: %s: %s', value, this._rotationStops[parseInt(value)]);
+        return this._rotationStops[parseInt(value)];
+    }
+
+    convertRotationSpeedFromTuyaToHomeKit(value) {
+        this.log.debug('convertRotationSpeedFromTuyaToHomeKit: %s: %s', value, this.getKeyByValue(this._rotationStops, value));
+        return this.device.context.fanSpeedSteps ? '' + this.getKeyByValue(this._rotationStops, value) : this.getKeyByValue(this._rotationStops, value);
     }
 
 }


### PR DESCRIPTION
I've added support for the Breville Smart Air Connect air purifier (and presumably others in the same range). It has some quicks, including expecting commands as text labels rather than integers. I've changed _rotationStops to a dict to lookup the correct command for each percent power setting and hard-coded some of the other labels in. I've also moved the text `Air Quality` characteristic to DP22, which is where it shows up on the Breville. 

I have tested this on the Breville, but I don't have any others to test, so there may be some breaking changes here, sorry.