### PR TITLE
Sync the cachedAccessories displayName with the configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,6 +214,13 @@ class TuyaLan {
             isCached = false;
         }
 
+        if (accessory && accessory.displayName !== deviceConfig.name) {
+            this.log.info(
+                "Configuration name %s differs from cached displayName %s. Updating cached displayName to %s ",
+                deviceConfig.name, accessory.displayName, deviceConfig.name);
+            accessory.displayName = deviceConfig.name;
+        }
+
         this.cachedAccessories.set(deviceConfig.UUID, new Accessory(this, accessory, device, !isCached));
     }
 


### PR DESCRIPTION
Update the cachedAccessories displayName when it differs from the name in the configuration. This allows you to re-purpose an accessory while eliminating potentially confusing log messages that show different names.