### PR TITLE
Prevent an ECONNRESET storm when accessories turn off

### DIFF
--- a/lib/TuyaAccessory.js
+++ b/lib/TuyaAccessory.js
@@ -47,6 +47,7 @@ class TuyaAccessory extends EventEmitter {
         this._incrementAttemptCounter();
 
         (this._socket.reconnect = () => {
+            console.log(`[TuyaAccessory DEBUG] reconnect called for ${this.context.name}`);
             if (this._socket._pinger) {
                 clearTimeout(this._socket._pinger);
                 this._socket._pinger = null;
@@ -57,6 +58,11 @@ class TuyaAccessory extends EventEmitter {
                 this._socket._connTimeout = null;
             }
 
+            if (this._socket._errorReconnect) {
+                clearTimeout(this._socket._errorReconnect);
+                this._socket._errorReconnect = null;
+            }
+
             this._socket.setKeepAlive(true);
             this._socket.setNoDelay(true);
 
@@ -65,6 +71,8 @@ class TuyaAccessory extends EventEmitter {
                 //this._socket.destroy();
                 //process.nextTick(this._connect.bind(this));
             }, (this.context.connectTimeout || 30) * 1000);
+
+            this._incrementAttemptCounter();
 
             this._socket.connect(this.context.port, this.context.ip);
         })();
@@ -92,8 +100,9 @@ class TuyaAccessory extends EventEmitter {
 
             this.connected = true;
             this.emit('connect');
-            setTimeout(() => this._socket._ping(), 1000);
-
+            if (this._socket._pinger)
+                clearTimeout(this._socket._pinger);
+            this._socket._pinger = setTimeout(() => this._socket._ping(), 1000);
 
             if (this.context.intro === false) {
                 this.emit('change', {}, this.state);
@@ -134,6 +143,7 @@ class TuyaAccessory extends EventEmitter {
             console.log(`[TuyaAccessory] Socket had a problem and will reconnect to ${this.context.name} (${err && err.code || err})`);
 
             if (err && (err.code === 'ECONNRESET' || err.code === 'EPIPE') && this._connectionAttempts < 10) {
+                console.log(`[TuyaAccessory DEBUG] Reconnecting with connection attempts =  ${this._connectionAttempts}`);
                 return process.nextTick(this._socket.reconnect.bind(this));
             }
 
@@ -151,9 +161,13 @@ class TuyaAccessory extends EventEmitter {
                 }
             }
 
-            setTimeout(() => {
-                process.nextTick(this._connect.bind(this));
-            }, delay);
+            if (!this._socket._errorReconnect) {
+                console.log(`[TuyaAccessory DEBUG] after error setting _connect in ${delay}ms`);
+                this._socket._errorReconnect = setTimeout(() => {
+                    console.log(`[TuyaAccessory DEBUG] executing _connect after ${delay}ms delay`);
+                    process.nextTick(this._connect.bind(this));
+                }, delay);
+            }
         });
 
         this._socket.on('close', err => {
@@ -170,6 +184,7 @@ class TuyaAccessory extends EventEmitter {
     _incrementAttemptCounter() {
         this._connectionAttempts++;
         setTimeout(() => {
+            console.log(`[TuyaAccessory DEBUG] decrementing this._connectionAttempts, currently ${this._connectionAttempts}`);
             this._connectionAttempts--;
         }, 10000);
     }


### PR DESCRIPTION
To prevent a fast ECONNRESET loop when turning off an accessory and turning it back on more than a few minutes later, e.g. to move and re-purpose it, did the following: In _socket.on('error') recorded the _connect() Timeout in this._socket._errorReconnect and tested that value before setting another Timeout to prevent scheduling two _connect() calls; Added _errorReconnect to the list of Timeouts cleared in _connect(); In this._socket.reconnect, incremented the Attempt Counter this._connectionAttempts just before the call to this._socket.connect(). The attempt counter was being incremented only on _connect(), not on reconnect; In _socket.on('connect'), cleared an existing pinger Timeout before setting another one; Added several DEBUG console.log statements to help trace what was happening and confirm the above changes worked.