### PR TITLE
Fix crash on launch for garage accessory with ReferenceError: dps is not defined

### DIFF
--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -287,7 +287,7 @@ class GarageDoorAccessory extends BaseAccessory {
                 return this.currentClosed;
             } else {
                 this._alwaysLog('_getCurrentDoorState UNKNOWN STATUS ' +
-                    JSON.stringify(dps[this.dpStatus]));
+                    JSON.stringify(dpStatusValue));
             }
         }
     }


### PR DESCRIPTION
Legacy code was not updated with latest parameter name

Change https://github.com/iRayanKhan/homebridge-tuya/commit/82c6063693f57032bbbf8fbf53fc4741fff6307d#diff-62ef107d13ba44e1952ec6ddf70355ce5f42a30e42a94ed009155ad26881a24aL88