### PR TITLE
Added dpStatus configuration for Wofea garage door

### DIFF
--- a/lib/GarageDoorAccessory.js
+++ b/lib/GarageDoorAccessory.js
@@ -21,6 +21,9 @@ const GARAGE_DOOR_CLOSING = 'closing';
 // Kogan manufacturer name
 const GARAGE_DOOR_MANUFACTURER_KOGAN = 'Kogan';
 
+// Wofea manufacturer name
+const GARAGE_DOOR_MANUFACTURER_WOFEA = 'Wofea';
+
 // main code
 class GarageDoorAccessory extends BaseAccessory {
     static getCategory(Categories) {
@@ -65,6 +68,15 @@ class GarageDoorAccessory extends BaseAccessory {
         }
     }
 
+    // function to return true if the garage door manufacturer is Wofea
+    _isWofea() {
+      if (this.manufacturer === GARAGE_DOOR_MANUFACTURER_WOFEA.trim()) {
+          return true;
+      } else {
+          return false;
+      }
+  }
+
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
         const service = this.accessory.getService(Service.GarageDoorOpener);
@@ -77,14 +89,16 @@ class GarageDoorAccessory extends BaseAccessory {
             this.debug = false;
         }
 
-        // test if this is a Kogan opener, i.e. has Kogan in upper or lower case in
-        // the manufacturer field and set the manufacturer property for later
-        // comparisons. If the manufacturer field is not Kogan and is not empty, set
-        // the manufacturer property to that value. Otherwise, set the manufacturer
-        // property to a blank string.
+        // Set the manufacturer string
+        // If the manufacturer string matches a known manufacturer, set to that string
+        // Otherwise set the manufacturer to the defined value
+        // Otherwise set the manufacturer to a blank string
         if (this.device.context.manufacturer.trim().toLowerCase() ===
             GARAGE_DOOR_MANUFACTURER_KOGAN.trim().toLowerCase()) {
             this.manufacturer = GARAGE_DOOR_MANUFACTURER_KOGAN.trim();
+        } else if (this.device.context.manufacturer.trim().toLowerCase() ===
+            GARAGE_DOOR_MANUFACTURER_Wofea.trim().toLowerCase()) {
+            this.manufacturer = this.device.context.manufacturer.trim();
         } else if (this.device.context.manufacturer) {
             this.manufacturer = this.device.context.manufacturer.trim();
         } else {
@@ -95,9 +109,16 @@ class GarageDoorAccessory extends BaseAccessory {
             // Kogan SmarterHome Wireless Garage Door Opener
             this._debugLog(
                 '_registerCharacteristics setting dpAction and dpStatus for ' +
-                GARAGE_DOOR_MANUFACTURER_KOGAN + ' door');
+                GARAGE_DOOR_MANUFACTURER_KOGAN + ' garage door');
             this.dpAction = this._getCustomDP(this.device.context.dpAction) || '101';
             this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '102';
+        } else if (this._isWofea()) {
+            // Wofea Wifi Switch Smart Garage Door Opener
+            this._debugLog(
+                '_registerCharacteristics setting dpAction and dpStatus for ' +
+                GARAGE_DOOR_MANUFACTURER_WOFEA + ' garage door');
+            this.dpAction = this._getCustomDP(this.device.context.dpAction) || '1';
+            this.dpStatus = this._getCustomDP(this.device.context.dpStatus) || '101';
         } else {
             // the original garage door opener
             this._debugLog(


### PR DESCRIPTION
Wofea uses `dp 101` to indicate door status.

**Examples**
Closed
```{"1":false,"7":0,"101":false}```
Open
```{"1":true,"7":0,"101":true}```

Note `dp 1` is still used for state changes.