### PR TITLE
Allow numbers and strings not beginning with "L" and "H"...

### DIFF
--- a/lib/ConvectorAccessory.js
+++ b/lib/ConvectorAccessory.js
@@ -31,13 +31,13 @@ class ConvectorAccessory extends BaseAccessory {
 
         this.cmdLow = 'LOW';
         if (this.device.context.cmdLow) {
-            if (/^l[a-z]+$/i.test(this.device.context.cmdLow)) this.cmdLow = ('' + this.device.context.cmdLow).trim();
+            if (/^[a-z0-9]+$/i.test(this.device.context.cmdLow)) this.cmdLow = ('' + this.device.context.cmdLow).trim();
             else throw new Error('The cmdLow doesn\'t appear to be valid: ' + this.device.context.cmdLow);
         }
 
         this.cmdHigh = 'HIGH';
         if (this.device.context.cmdHigh) {
-            if (/^h[a-z]+$/i.test(this.device.context.cmdHigh)) this.cmdHigh = ('' + this.device.context.cmdHigh).trim();
+            if (/^[a-z0-9]+$/i.test(this.device.context.cmdHigh)) this.cmdHigh = ('' + this.device.context.cmdHigh).trim();
             else throw new Error('The cmdHigh doesn\'t appear to be valid: ' + this.device.context.cmdHigh);
         }
 


### PR DESCRIPTION
...to be valid values for cmdLow and cmdHigh

eg.: for Rohnson R-029, dpRotationSpeed can be used for heating power (1-3) or for mode ("smart"/"auto"), but with the limitation of the values by the first characters "l" or "h" it's not usable at all.