### PR TITLE
Add SimpleDimmer2Accessory which supports certain Gosund Smart Dimmer…

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const DehumidifierAccessory = require('./lib/DehumidifierAccessory');
 const ConvectorAccessory = require('./lib/ConvectorAccessory');
 const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
 const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
+const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
 const SimpleBlinds2Accessory = require('./lib/SimpleBlinds2Accessory');
 const SimpleHeaterAccessory = require('./lib/SimpleHeaterAccessory');
@@ -40,6 +41,7 @@ const CLASS_DEF = {
     convector: ConvectorAccessory,
     garagedoor: GarageDoorAccessory,
     simpledimmer: SimpleDimmerAccessory,
+    simpledimmer2: SimpleDimmer2Accessory,    
     simpleblinds: SimpleBlindsAccessory,
     simpleblinds2: SimpleBlinds2Accessory,
     simpleheater: SimpleHeaterAccessory,

--- a/lib/SimpleDimmer2Accessory.js
+++ b/lib/SimpleDimmer2Accessory.js
@@ -1,0 +1,54 @@
+const BaseAccessory = require('./BaseAccessory');
+
+class SimpleDimmer2Accessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.LIGHTBULB;
+    }
+
+    constructor(...props) {
+        super(...props);
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+
+        this.accessory.addService(Service.Lightbulb, this.device.context.name);
+
+        super._registerPlatformAccessory();
+    }
+
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.Lightbulb);
+        this._checkServiceName(service, this.device.context.name);
+
+        this.dpPower = this._getCustomDP(this.device.context.dpPower) || '1';
+        this.dpBrightness = '3'; //this._getCustomDP(this.device.context.dpBrightness) || this._getCustomDP(this.device.context.dp) || '2';
+
+        const characteristicOn = service.getCharacteristic(Characteristic.On)
+            .updateValue(dps[this.dpPower])
+            .on('get', this.getState.bind(this, this.dpPower))
+            .on('set', this.setState.bind(this, this.dpPower));
+
+        const characteristicBrightness = service.getCharacteristic(Characteristic.Brightness)
+            .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
+            .on('get', this.getBrightness.bind(this))
+            .on('set', this.setBrightness.bind(this));
+
+        this.device.on('change', changes => {
+            if (changes.hasOwnProperty(this.dpPower) && characteristicOn.value !== changes[this.dpPower]) characteristicOn.updateValue(changes[this.dpPower]);
+            if (changes.hasOwnProperty(this.dpBrightness) && this.convertBrightnessFromHomeKitToTuya(characteristicBrightness.value) !== changes[this.dpBrightness])
+                characteristicBrightness.updateValue(this.convertBrightnessFromTuyaToHomeKit(changes[this.dpBrightness]));
+        });
+    }
+
+    getBrightness(callback) {
+        callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
+    }
+
+    setBrightness(value, callback) {
+        this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
+    }
+}
+
+module.exports = SimpleDimmer2Accessory;


### PR DESCRIPTION
I purchased some Gosund Smart Dimmer switches from Amazon. The first batch of four worked fine with the standard SimpleDimmerAccessory. But my second purchase of 2 switches did not dim properly. These switches also present themselves slightly differently in the Tuya Smart app, so they're different somehow internally although they physically look identical.

What I found from experimentation is that these switches are looking for a dimming command on parameter 2, scaled as a byte, rather than the other switches wanting dimming on parameter 2 scaled 0-1000. SimpleDimmerAccessory uses parameter 2.

To fix this, I cloned SimpleDimmerAccessory and created SimpleDimmer2Accessory, changing the dimming to happen on parameter 3. I'm submitting these changes here as a pull request. If there are better ways to do what I'm attempting here, I'm very open to making changes. I would very much like to get the functionality into the base plugin so I don't have to maintain a fork for my use.

These Gosund switches are some of the most economical on Amazon, and are actually quite nice, so I'm assuming others will want this functionality soon if they don't already.

Thanks for your consideration.