### PR TITLE
Updated setMultiState Function

### DIFF
--- a/lib/BaseAccessory.js
+++ b/lib/BaseAccessory.js
@@ -81,9 +81,12 @@ class BaseAccessory {
 
     setMultiState(dps, callback) {
         if (!this.device.connected) return callback(true);
-
-        const ret = this.device.update(dps);
-        callback && callback(!ret);
+        for (const dp in dps) {
+            if (dps.hasOwnProperty(dp) && dps[dp] !== this.device.state[dp]){
+                this.__ret = this.device.update({[dp.toString()] : dps[dp]});
+            }
+        }
+        callback && callback(!this.__ret);
     }
 
     getDividedState(dp, divisor, callback) {


### PR DESCRIPTION
Updated the function that issues a setState for devices; this will ensure values already true in the device dps is not sent again in another command. While this will still send separate commands it will eliminate continously getting a light to turn ON while changing brightness in accordance with Issue #252 - this issue is now closed.