### PR TITLE
Removed RapidCommand Safety Net

### DIFF
--- a/lib/RGBTWLightAccessory.js
+++ b/lib/RGBTWLightAccessory.js
@@ -160,9 +160,6 @@ class RGBTWLightAccessory extends BaseAccessory {
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
 
-        // Avoid cross-mode complications due rapid commands
-        this.device.state[this.dpMode] = this.cmdWhite;
-
         this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
     }
 
@@ -221,9 +218,6 @@ class RGBTWLightAccessory extends BaseAccessory {
 
 
         if (this.device.state[this.dpMode] === this.cmdWhite && isSham) return callEachBack();
-
-        // Avoid cross-mode complications due rapid commands
-        this.device.state[this.dpMode] = this.cmdColor;
 
         this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue}, callEachBack);
     }


### PR DESCRIPTION
- Removed 
  // Avoid cross-mode complications due rapid commands
  this.device.state[this.dpMode] = this.cmdWhite;