### PR TITLE
Removed RapidCommand Safety Net

### DIFF
--- a/lib/RGBTWOutletAccessory.js
+++ b/lib/RGBTWOutletAccessory.js
@@ -231,9 +231,6 @@ class RGBTWOutletAccessory extends BaseAccessory {
         this.characteristicHue.updateValue(newColor.h);
         this.characteristicSaturation.updateValue(newColor.s);
 
-        // Avoid cross-mode complications due rapid commands
-        this.device.state[this.dpMode] = this.cmdWhite;
-
         this.setMultiState({[this.dpMode]: this.cmdWhite, [this.dpColorTemperature]: this.convertColorTemperatureFromHomeKitToTuya(value)}, callback);
     }
 
@@ -290,11 +287,7 @@ class RGBTWOutletAccessory extends BaseAccessory {
         const newValue = this.convertColorFromHomeKitToTuya(this._pendingHueSaturation.props);
         this._pendingHueSaturation = null;
 
-
         if (this.device.state[this.dpMode] === this.cmdWhite && isSham) return callEachBack();
-
-        // Avoid cross-mode complications due rapid commands
-        this.device.state[this.dpMode] = this.cmdColor;
 
         this.setMultiState({[this.dpMode]: this.cmdColor, [this.dpColor]: newValue}, callEachBack);
     }


### PR DESCRIPTION
- Removed 
  // Avoid cross-mode complications due rapid commands
  this.device.state[this.dpMode] = this.cmdWhite;