### PR TITLE
Fix empty manufacturer error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea

--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ class TuyaLan {
         if (!accessory) {
             accessory = new PlatformAccessory(deviceConfig.name, deviceConfig.UUID, Accessory.getCategory(Categories));
             accessory.getService(Service.AccessoryInformation)
-                .setCharacteristic(Characteristic.Manufacturer, (deviceConfig.manufacturer).trim())
+                .setCharacteristic(Characteristic.Manufacturer, deviceConfig.manufacturer || "Unknown")
                 .setCharacteristic(Characteristic.Model, deviceConfig.model || "Unknown")
                 .setCharacteristic(Characteristic.SerialNumber, deviceConfig.id.slice(8));
 


### PR DESCRIPTION
When adding a new Device and leaving the "Manufacturer" field blank (Which is a non-required field) we get the following error:

```
[TuyaDiscovery] Failed to parse discovery response on port 6667: {}
```

The exception:
```
TypeError: Cannot read property 'trim' of undefined
    at TuyaLan.addAccessory (/homebridge/node_modules/homebridge-tuya/index.js:215:93)
    at TuyaDiscovery.<anonymous> (/homebridge/node_modules/homebridge-tuya/index.js:129:22)
    at TuyaDiscovery.emit (events.js:315:20)
    at TuyaDiscovery._onDiscover (/homebridge/node_modules/homebridge-tuya/lib/TuyaDiscovery.js:156:14)
    at TuyaDiscovery._onDgramMessage (/homebridge/node_modules/homebridge-tuya/lib/TuyaDiscovery.js:135:58)
    at Socket.emit (events.js:315:20)
    at UDP.onMessage (dgram.js:919:8)
```

The old .trim() on line 212 is not needed anymore, it was used when concatenating PLATFORM_NAME:
```
if (!accessory) {
    accessory = new PlatformAccessory(deviceConfig.name, deviceConfig.UUID, Accessory.getCategory(Categories));
    accessory.getService(Service.AccessoryInformation)
        .setCharacteristic(Characteristic.Manufacturer, (PLATFORM_NAME + ' ' + deviceConfig.manufacturer).trim())
        .setCharacteristic(Characteristic.Model, deviceConfig.model || "Unknown")
        .setCharacteristic(Characteristic.SerialNumber, deviceConfig.id.slice(8));

    isCached = false;
}
```