### PR TITLE
Allow Empty Config

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,8 @@ class TuyaLan {
     }
 
     configureAccessory(accessory) {
-        if (accessory instanceof PlatformAccessory && this._expectedUUIDs.includes(accessory.UUID)) {
+        // also checks null objects or empty config - this._expectedUUIDs
+        if (accessory instanceof PlatformAccessory && this._expectedUUIDs && this._expectedUUIDs.includes(accessory.UUID)) {
             this.cachedAccessories.set(accessory.UUID, accessory);
             accessory.services.forEach(service => {
                 if (service.UUID === Service.AccessoryInformation.UUID) return;


### PR DESCRIPTION
Allows for plugin to work with empty configuration file for tester and first time users.