### PR TITLE
Minor changes to DehumidifierAccessory

### DIFF
--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -137,6 +137,7 @@ class DehumidifierAccessory extends BaseAccessory {
             }
 
             if (changes.hasOwnProperty(this.getDp('Humidity')) && this.characteristicHumidity.value !== changes[this.getDp('Humidity')]) this.characteristicHumidity.updateValue(changes[this.getDp('Humidity')]);
+            if (changes.hasOwnProperty(this.getDp('CurrentHumidity')) && characteristicCurrentHumidity.value !== changes[this.getDp('CurrentHumidity')]) t.characteristicCurrentHumidity.updateValue(changes[this.getDp('CurrentHumidity')]);
 
             if (characteristicChildLock && changes.hasOwnProperty(this.getDp('ChildLock'))) {
                 const newChildLock = this._getLockTargetState(changes[this.getDp('ChildLock')]);

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -131,7 +131,7 @@ class DehumidifierAccessory extends BaseAccessory {
                     characteristicActive.updateValue(newActive);
 
                     if (!changes.hasOwnProperty(this.getDp('FanSpeed'))) {
-                        characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
+                        characteristicSpeed.updateValue(this._getRotationSpeed(state));
                     }
                 }
             }
@@ -144,9 +144,9 @@ class DehumidifierAccessory extends BaseAccessory {
                 if (characteristicChildLock.value !== newChildLock) characteristicChildLock.updateValue(newChildLock);
             }
 
-            if (changes.hasOwnProperty(this.getDp('FanSpeed'))) {
-                const newSpeed = this._getRotationSpeed(state);
-                if (characteristicSpeed.value !== newSpeed) characteristicSpeed.updateValue(newSpeed);
+            if (characteristicRotationSpeed && changes.hasOwnProperty(this.getDp('FanSpeed'))) {
+                const newRotationSpeed = this._getRotationSpeed(state);
+                if (characteristicRotationSpeed.value !== newRotationSpeed) characteristicRotationSpeed.updateValue(newRotationSpeed);
             }
         });
     }

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -136,7 +136,7 @@ class DehumidifierAccessory extends BaseAccessory {
                 }
             }
 
-            if (changes.hasOwnProperty('Humidity') && this.characteristicHumidity.value !== changes[this.getDp('Humidity')]) this.characteristicHumidity.updateValue(changes[this.getDp('Humidity')]);
+            if (changes.hasOwnProperty(this.getDp('Humidity')) && this.characteristicHumidity.value !== changes[this.getDp('Humidity')]) this.characteristicHumidity.updateValue(changes[this.getDp('Humidity')]);
 
             if (characteristicChildLock && changes.hasOwnProperty(this.getDp('ChildLock'))) {
                 const newChildLock = this._getLockTargetState(changes[this.getDp('ChildLock')]);

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -72,10 +72,10 @@ class DehumidifierAccessory extends BaseAccessory {
         const service = this.accessory.getService(Service.HumidifierDehumidifier);
         this._checkServiceName(service, this.device.context.name);
 
-        let characteristicSpeed;
+        let characteristicRotationSpeed;
         if (!this.device.context.noSpeed) {
             let fanService = this.accessory.getService(Service.Fan);
-            characteristicSpeed = fanService.getCharacteristic(Characteristic.RotationSpeed)
+            characteristicRotationSpeed = fanService.getCharacteristic(Characteristic.RotationSpeed)
                 .setProps({
                     minValue: this.device.context.minSpeed || 1,
                     maxValue: this.device.context.maxSpeed || 2,
@@ -134,7 +134,7 @@ class DehumidifierAccessory extends BaseAccessory {
                     characteristicActive.updateValue(newActive);
 
                     if (!changes.hasOwnProperty(this.getDp('FanSpeed'))) {
-                        characteristicSpeed.updateValue(this._getRotationSpeed(state));
+                        characteristicRotationSpeed.updateValue(this._getRotationSpeed(state));
                     }
                 }
             }

--- a/lib/DehumidifierAccessory.js
+++ b/lib/DehumidifierAccessory.js
@@ -33,7 +33,9 @@ class DehumidifierAccessory extends BaseAccessory {
     _registerPlatformAccessory() {
         const {Service} = this.hap;
 
-        this.accessory.addService(Service.TemperatureSensor, this.device.context.name);
+        if (!this.device.context.noTemperature) {
+            this.accessory.addService(Service.TemperatureSensor, this.device.context.name);
+        }
         this.accessory.addService(Service.HumiditySensor, this.device.context.name);
         this.accessory.addService(Service.HumidifierDehumidifier, this.device.context.name);
 
@@ -55,11 +57,12 @@ class DehumidifierAccessory extends BaseAccessory {
         infoService.getCharacteristic(Characteristic.Manufacturer).updateValue(this.device.context.manufacturer);
         infoService.getCharacteristic(Characteristic.Model).updateValue(this.device.context.model);
 
-        const characteristicTemperature = this.accessory.getService(Service.TemperatureSensor)
-            .getCharacteristic(Characteristic.CurrentTemperature)
-            .updateValue(this._getCurrentTemperature(dps[this.getDp('CurrentTemperature')]))
-            .on('get', this.getCurrentTemperature.bind(this));
-
+        if (!this.device.context.noTemperature) {
+            const characteristicTemperature = this.accessory.getService(Service.TemperatureSensor)
+                .getCharacteristic(Characteristic.CurrentTemperature)
+                .updateValue(this._getCurrentTemperature(dps[this.getDp('CurrentTemperature')]))
+                .on('get', this.getCurrentTemperature.bind(this));
+        }
 
         const characteristicCurrentHumidity = this.accessory.getService(Service.HumiditySensor)
             .getCharacteristic(Characteristic.CurrentRelativeHumidity)


### PR DESCRIPTION
The changes included in this PR are mostly based on my own experience with a Smart Life capable dehumidifier.

- Handle dehumidifiers which have no temperature sensor
- Trivial fix to supporting changing of target humidity value
- Proactively track current humidity value changes as reported by a dehumidifier
- Add uniformity with RotationSpeed characteristic declarations from other Tuya accessories in this plugin