### PR TITLE
Adding thermostat feature

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -1,13 +1,23 @@
+<p align="center">
+    <img src="https://github.com/iRayanKhan/Assets-Repo/blob/master/Tuya-Plugin-Branding.png?raw=true" height="100"><br>
+</p>
+
+
 <span align="center">
 
 # Homebridge-Tuya
 
+[![npm](https://img.shields.io/npm/v/homebridge-tuya.svg)](https://www.npmjs.com/package/homebridge-tuya)
+[![npm](https://img.shields.io/npm/dt/homebridge-tuya.svg)](https://www.npmjs.com/package/homebridge-tuya)
+[![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
+
+
 </span>
+
 
 
 Control your supported Tuya accessories locally in HomeKit
 
-* [Why This Fork?](#why-this-fork-exists)
 * [Supported Device Types](#supported-device-types)
 * [Installation Instructions](#installation-instructions)
 * [Configuration](#configuration)
@@ -15,22 +25,7 @@ Control your supported Tuya accessories locally in HomeKit
 * [Troubleshooting](#troubleshooting)
 * [Credits](#credits)
 * [License](#license)
-
-## Why This Fork Exists
-
-We recently bought a new house that comes with a WiFi thermostat which controls the electric floor heating in our bathroom. The make and model of which are [Magnum MRC Remote control]( https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) which is supported by an OEM white label Tuya application. Unfortunately this app does not directly integrate with HomeKit, therefore a Homebridge plugin was required. The current version of the plugin that this fork is based of [homebridge-tuya](https://github.com/iRayanKhan/homebridge-tuya) does not provide support for thermostat devices where custom names are provided to select specific heating schedules. In the case of our thermostat,  **AUTO** runs the regular schedule, and **MANUAL**, **FROST** or **HOLIDAY** should be used to deviate from the regular programming.
-
-This plugin aims to solve this need by splitting out the operational state of the thermostat (heating vs. idle), and the currently active heating mode (schedule vs. override), and provides the option to use the devices own enumerations for each operating state
-
-For our specific device [MRC Remote control](https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) these are the required settings:
-
-| Function | Name in config | DP | Possible Values |
-| --- | --- | --- | --- |
-| Heating indicator | dpActive | 118 | "warming" (corresponds to idle) / "heating" (corresponds to heating) |
-| Program status | dpProgramState | 103 | "AUTO" / "MANUAL" / "FROST" / "HOLIDAY" |
-| Desired temperature | dpDesiredTemperature | 102 | temperature multiplied by 10 |
-| Current temperature | dpCurrentTemperature | 106 | temperature multiplied by 10 |
-
+* [Donating](#donating)
 
 ## Supported Device Types
 > Click the number next to your device to find the possible DataPoint "DP" values, then add as needed to your config.
@@ -51,7 +46,6 @@ For our specific device [MRC Remote control](https://www.magnumheating.com/produ
 * Oil Diffusers<sup>[13](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types)</sup>
 * Outlets<sup>[14](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types#outlets)</sup>
 * Switches<sup>[15](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types)</sup>
-* Thermostats (added in this fork)
 
 Note: Motion, and other sensor types don't behave well with responce requests, so they will not be added. 
 
@@ -60,25 +54,21 @@ Note: Motion, and other sensor types don't behave well with responce requests, s
 
 #### Option 1: Install via Homebridge Config UI X:
 
-1. Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya`.
-2. Overwrite the **./index.js**, **./lib/SimpleThermostatAccessory** and **./config.schema.json**
+Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya`.
 
 #### Option 2: Manually Install:
 
-1. Run the following npm command:
 ```
 sudo npm install -g homebridge-tuya
 ```
-2. Overwrite the **./index.js**, **./lib/SimpleThermostatAccessory** and **./config.schema.json**
-
 
 ## Configuration
 > UI
 
 1. Navigate to the Plugins page in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x).
 2. Click the **Settings** button for the Tuya plugin.
-3. Add your device types.
-4. Add device parameters.
+3. Add your device types
+4. Add device parameters<sup>[10](apple.com/)</sup>
 5. Restart Homebridge for the changes to take effect.
 
 > Manual
@@ -102,10 +92,15 @@ If you have new accessory logic for a new device, please add a function defined 
 
 ## Credits
 
-* [AMoo-Miki](https://github.com/AMoo-Miki) - developer of the [Tuya-Lan](https://github.com/AMoo-Miki/homebridge-tuya-lan) plugin which this plugin is based off.
-* [iRayanKhan](https://github.com/iRayanKhan) - developer of the [homebridge-tuya](https://github.com/iRayanKhan/homebridge-tuya) plugin which this is a fork off.
+* [AMoo-Miki](https://github.com/AMoo-Miki) - developer of the [Tuya-Lan](https://github.com/AMoo-Miki/homebridge-tuya-lan) plugin which this plugin is based off. 
 * mxDanger - Plugin branding.
 * [CodeTheWeb](https://github.com/CodeTheWeb) - developer of [TuyaApi](https://github.com/codetheweb/tuyapi), who gratiously provided this repo's name.
 * [Oznu](https://github.com/oznu) - developer of Homebridge, added ```config.schema.json``` , fixed dependencies, and helped inspire this readME off his [gsh](https://github.com/oznu/homebridge-gsh) plugin.
 
 ## License
+
+
+
+## Donating
+
+Please donate to a local pet shelter, or food pantry. It's been a wild time, but we can do our part by helping others. 

--- a/Readme.MD
+++ b/Readme.MD
@@ -1,19 +1,8 @@
-<p align="center">
-    <img src="https://github.com/iRayanKhan/Assets-Repo/blob/master/Tuya-Plugin-Branding.png?raw=true" height="100"><br>
-</p>
-
-
 <span align="center">
 
 # Homebridge-Tuya
 
-[![npm](https://img.shields.io/npm/v/homebridge-tuya.svg)](https://www.npmjs.com/package/homebridge-tuya)
-[![npm](https://img.shields.io/npm/dt/homebridge-tuya.svg)](https://www.npmjs.com/package/homebridge-tuya)
-[![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
-
-
 </span>
-
 
 
 Control your supported Tuya accessories locally in HomeKit
@@ -25,7 +14,6 @@ Control your supported Tuya accessories locally in HomeKit
 * [Troubleshooting](#troubleshooting)
 * [Credits](#credits)
 * [License](#license)
-* [Donating](#donating)
 
 ## Supported Device Types
 > Click the number next to your device to find the possible DataPoint "DP" values, then add as needed to your config.
@@ -46,6 +34,7 @@ Control your supported Tuya accessories locally in HomeKit
 * Oil Diffusers<sup>[13](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types)</sup>
 * Outlets<sup>[14](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types#outlets)</sup>
 * Switches<sup>[15](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types)</sup>
+* Thermostats (added in this fork)
 
 Note: Motion, and other sensor types don't behave well with responce requests, so they will not be added. 
 
@@ -54,21 +43,25 @@ Note: Motion, and other sensor types don't behave well with responce requests, s
 
 #### Option 1: Install via Homebridge Config UI X:
 
-Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya`.
+1. Search for "Tuya" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-tuya`.
+2. Overwrite the **./index.js**, **./lib/SimpleThermostatAccessory** and **./config.schema.json**
 
 #### Option 2: Manually Install:
 
+1. Run the following npm command:
 ```
 sudo npm install -g homebridge-tuya
 ```
+2. Overwrite the **./index.js**, **./lib/SimpleThermostatAccessory** and **./config.schema.json**
+
 
 ## Configuration
 > UI
 
 1. Navigate to the Plugins page in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x).
 2. Click the **Settings** button for the Tuya plugin.
-3. Add your device types
-4. Add device parameters<sup>[10](apple.com/)</sup>
+3. Add your device types.
+4. Add device parameters.
 5. Restart Homebridge for the changes to take effect.
 
 > Manual
@@ -92,15 +85,10 @@ If you have new accessory logic for a new device, please add a function defined 
 
 ## Credits
 
-* [AMoo-Miki](https://github.com/AMoo-Miki) - developer of the [Tuya-Lan](https://github.com/AMoo-Miki/homebridge-tuya-lan) plugin which this plugin is based off. 
+* [AMoo-Miki](https://github.com/AMoo-Miki) - developer of the [Tuya-Lan](https://github.com/AMoo-Miki/homebridge-tuya-lan) plugin which this plugin is based off.
+* [iRayanKhan](https://github.com/iRayanKhan) - developer of the [homebridge-tuya](https://github.com/iRayanKhan/homebridge-tuya) plugin which this is a fork off.
 * mxDanger - Plugin branding.
 * [CodeTheWeb](https://github.com/CodeTheWeb) - developer of [TuyaApi](https://github.com/codetheweb/tuyapi), who gratiously provided this repo's name.
 * [Oznu](https://github.com/oznu) - developer of Homebridge, added ```config.schema.json``` , fixed dependencies, and helped inspire this readME off his [gsh](https://github.com/oznu/homebridge-gsh) plugin.
 
 ## License
-
-
-
-## Donating
-
-Please donate to a local pet shelter, or food pantry. It's been a wild time, but we can do our part by helping others. 

--- a/Readme.MD
+++ b/Readme.MD
@@ -7,6 +7,7 @@
 
 Control your supported Tuya accessories locally in HomeKit
 
+* [Why This Fork?](#why-this-fork-exists)
 * [Supported Device Types](#supported-device-types)
 * [Installation Instructions](#installation-instructions)
 * [Configuration](#configuration)
@@ -14,6 +15,22 @@ Control your supported Tuya accessories locally in HomeKit
 * [Troubleshooting](#troubleshooting)
 * [Credits](#credits)
 * [License](#license)
+
+## Why This Fork Exists
+
+We recently bought a new house that comes with a WiFi thermostat which controls the electric floor heating in our bathroom. The make and model of which are [Magnum MRC Remote control]( https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) which is supported by an OEM white label Tuya application. Unfortunately this app does not directly integrate with HomeKit, therefore a Homebridge plugin was required. The current version of the plugin that this fork is based of [homebridge-tuya](https://github.com/iRayanKhan/homebridge-tuya) does not provide support for thermostat devices where custom names are provided to select specific heating schedules. In the case of our thermostat,  **AUTO** runs the regular schedule, and **MANUAL**, **FROST** or **HOLIDAY** should be used to deviate from the regular programming.
+
+This plugin aims to solve this need by splitting out the operational state of the thermostat (heating vs. idle), and the currently active heating mode (schedule vs. override), and provides the option to use the devices own enumerations for each operating state
+
+For our specific device [MRC Remote control](https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) these are the required settings:
+
+| Function | Name in config | DP | Possible Values |
+| --- | --- | --- | --- |
+| Heating indicator | dpActive | 118 | "warming" (corresponds to idle) / "heating" (corresponds to heating) |
+| Program status | dpProgramState | 103 | "AUTO" / "MANUAL" / "FROST" / "HOLIDAY" |
+| Desired temperature | dpDesiredTemperature | 102 | temperature multiplied by 10 |
+| Current temperature | dpCurrentTemperature | 106 | temperature multiplied by 10 |
+
 
 ## Supported Device Types
 > Click the number next to your device to find the possible DataPoint "DP" values, then add as needed to your config.

--- a/config.schema.json
+++ b/config.schema.json
@@ -85,6 +85,12 @@
                     ]
                   },
                   {
+                    "title": "Simple Thermostat",
+                    "enum": [
+                      "SimpleThermostat"
+                    ]
+                  },
+                  {
                     "title": "Garage Door",
                     "enum": [
                       "GarageDoor"
@@ -321,14 +327,14 @@
                 "type": "integer",
                 "placeholder": "15",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['AirConditioner','Convector', 'SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['AirConditioner','Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "maxTemperature": {
                 "type": "integer",
                 "placeholder": "40",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['AirConditioner','Convector', 'SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['AirConditioner','Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "minTemperatureSteps": {
@@ -340,23 +346,64 @@
               },
               "dpActive": {
                 "type": "integer",
-                "placeholder": "7",
+                "placeholder": "118",
+                "description": "DP that shows whether the thermostat is requesting heating or idle.",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
+                }
+              },
+              "dpProgramState": {
+                "type": "integer",
+                "placeholder": "103",
+                "description": "DP that shows what program the thermostat is in.",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
+                }
+              },
+              "heatingIndicatorOff": {
+                "type": "string",
+                "placeholder": "warming",
+                "description": "Value of dpActive that shows its idleing",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
+                }
+              },
+              "heatingIndicatorOn": {
+                "type": "string",
+                "placeholder": "heating",
+                "description": "Value of dpActive that shows its requesting heat",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
+                }
+              },
+              "scheduledHeatingOff": {
+                "type": "string",
+                "placeholder": "FROST",
+                "description": "Value of dpProgramState that shows that the schedule has been turned off",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
+                }
+              },
+              "scheduledHeatingOn": {
+                "type": "string",
+                "placeholder": "AUTO",
+                "description": "Value of dpProgramState that shows that the schedule has been turned on",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "dpDesiredTemperature": {
                 "type": "integer",
                 "placeholder": "2",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "dpCurrentTemperature": {
                 "type": "integer",
                 "placeholder": "3",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['Convector', 'SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "dpRotationSpeed": {
@@ -410,21 +457,21 @@
                 "type": "integer",
                 "placeholder": "1",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "thresholdTemperatureDivisor": {
                 "type": "integer",
                 "placeholder": "1",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "targetTemperatureDivisor": {
                 "type": "integer",
                 "placeholder": "1",
                 "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater', 'SimpleThermostat'].includes(model.devices[arrayIndices].type);"
                 }
               },
               "dpAction": {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
 const SimpleBlinds2Accessory = require('./lib/SimpleBlinds2Accessory');
 const SimpleHeaterAccessory = require('./lib/SimpleHeaterAccessory');
+const SimpleThermostatAccessory = require('./lib/SimpleThermostatAccessory');
 const SimpleFanAccessory = require('./lib/SimpleFanAccessory');
 const SimpleFanLightAccessory = require('./lib/SimpleFanLightAccessory');
 const SwitchAccessory = require('./lib/SwitchAccessory');
@@ -45,6 +46,7 @@ const CLASS_DEF = {
     simpleblinds: SimpleBlindsAccessory,
     simpleblinds2: SimpleBlinds2Accessory,
     simpleheater: SimpleHeaterAccessory,
+    simplethermostat: SimpleThermostatAccessory,
     switch: SwitchAccessory,
     fan: SimpleFanAccessory,
     fanlight: SimpleFanLightAccessory,

--- a/lib/SimpleThermostatAccessory.js
+++ b/lib/SimpleThermostatAccessory.js
@@ -1,0 +1,158 @@
+const BaseAccessory = require('./BaseAccessory');
+
+class SimpleThermostatAccessory extends BaseAccessory {
+    static getCategory(Categories) {
+        return Categories.AIR_HEATER;
+    }
+
+    constructor(...props) {
+        super(...props);
+    }
+
+    _registerPlatformAccessory() {
+        const {Service} = this.hap;
+
+        this.accessory.addService(Service.HeaterCooler, this.device.context.name);
+
+        super._registerPlatformAccessory();
+    }
+
+    _registerCharacteristics(dps) {
+        const {Service, Characteristic} = this.hap;
+        const service = this.accessory.getService(Service.HeaterCooler);
+        this._checkServiceName(service, this.device.context.name);
+
+        this.dpActive = this._getCustomDP(this.device.context.dpActive) || '1';
+        this.dpProgramState = this._getCustomDP(this.device.context.dpProgramState) || '1';
+        this.dpDesiredTemperature = this._getCustomDP(this.device.context.dpDesiredTemperature) || '2';
+        this.dpCurrentTemperature = this._getCustomDP(this.device.context.dpCurrentTemperature) || '3';
+        this.temperatureDivisor = parseInt(this.device.context.temperatureDivisor) || 1;
+        this.thresholdTemperatureDivisor = parseInt(this.device.context.thresholdTemperatureDivisor) || 1;
+        this.targetTemperatureDivisor = parseInt(this.device.context.targetTemperatureDivisor) || 1;
+        this.heatingIndicatorOff = this.device.context.heatingIndicatorOff || 'warming';
+        this.heatingIndicatorOn = this.device.context.heatingIndicatorOn || 'heating';
+        this.scheduledHeatingOff = this.device.context.scheduledHeatingOff || 'FROST';
+        this.scheduledHeatingOn = this.device.context.scheduledHeatingOn || 'AUTO';
+
+        const characteristicActive = service.getCharacteristic(Characteristic.Active)
+            .updateValue(this._getActive(dps[this.dpActive]))
+            .on('get', this.getActive.bind(this))
+            .on('set', this.setActive.bind(this));
+
+        service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
+            .updateValue(this._getCurrentHeaterCoolerState(dps))
+            .on('get', this.getCurrentHeaterCoolerState.bind(this));
+
+        service.getCharacteristic(Characteristic.TargetHeaterCoolerState)
+            .setProps({
+                minValue: 1,
+                maxValue: 1,
+                validValues: [Characteristic.TargetHeaterCoolerState.HEAT]
+            })
+            .updateValue(this._getTargetHeaterCoolerState())
+            .on('get', this.getTargetHeaterCoolerState.bind(this))
+            .on('set', this.setTargetHeaterCoolerState.bind(this));
+
+        const characteristicCurrentTemperature = service.getCharacteristic(Characteristic.CurrentTemperature)
+            .updateValue(this._getDividedState(dps[this.dpCurrentTemperature], this.temperatureDivisor))
+            .on('get', this.getDividedState.bind(this, this.dpCurrentTemperature, this.temperatureDivisor));
+
+
+        const characteristicHeatingThresholdTemperature = service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
+            .setProps({
+                minValue: this.device.context.minTemperature || 15,
+                maxValue: this.device.context.maxTemperature || 35,
+                minStep: this.device.context.minTemperatureSteps || 1
+            })
+            .updateValue(this._getDividedState(dps[this.dpDesiredTemperature], this.thresholdTemperatureDivisor))
+            .on('get', this.getDividedState.bind(this, this.dpDesiredTemperature, this.thresholdTemperatureDivisor))
+            .on('set', this.setTargetThresholdTemperature.bind(this));
+
+        this.characteristicHeatingThresholdTemperature = characteristicHeatingThresholdTemperature;
+
+        this.device.on('change', (changes, state) => {
+            if (changes.hasOwnProperty(this.dpActive)) {
+                const newActive = this._getActive(changes[this.dpActive]);
+                if (characteristicActive.value !== newActive) {
+                    characteristicActive.updateValue(newActive);
+                }
+            }
+
+            if (changes.hasOwnProperty(this.dpDesiredTemperature)) {
+                if (characteristicHeatingThresholdTemperature.value !== changes[this.dpDesiredTemperature])
+                    characteristicHeatingThresholdTemperature.updateValue(changes[this.dpDesiredTemperature * this.targetTemperatureDivisor]);
+            }
+
+            if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor));
+
+            console.log('[Tuya] Thermostat changed: ' + JSON.stringify(state));
+        });
+    }
+
+    getActive(callback) {
+        this.getState(this.dpProgramState, (err, dp) => {
+            if (err) return callback(err);
+
+            callback(null, this._getActive(dp));
+        });
+    }
+
+    _getActive(dp) {
+        const {Characteristic} = this.hap;
+        return dp == this.scheduledHeatingOff ? Characteristic.Active.INACTIVE : Characteristic.Active.ACTIVE;
+    }
+
+    setActive(value, callback) {
+        const {Characteristic} = this.hap;
+
+        switch (value) {
+            case Characteristic.Active.ACTIVE:
+                return this.setState(this.dpProgramState, this.scheduledHeatingOn, callback);
+
+            case Characteristic.Active.INACTIVE:
+                return this.setState(this.dpProgramState, this.scheduledHeatingOff, callback);
+        }
+
+        callback();
+    }
+
+    getCurrentHeaterCoolerState(callback) {
+        this.getState([this.dpActive], (err, dps) => {
+            if (err) return callback(err);
+
+            callback(null, this._getCurrentHeaterCoolerState(dps));
+        });
+    }
+
+    _getCurrentHeaterCoolerState(dps) {
+        const {Characteristic} = this.hap;
+        return dps[this.dpActive] == this.heatingIndicatorOn ? Characteristic.CurrentHeaterCoolerState.HEATING : Characteristic.CurrentHeaterCoolerState.IDLE;
+    }
+
+    getTargetHeaterCoolerState(callback) {
+        callback(null, this._getTargetHeaterCoolerState());
+    }
+
+    _getTargetHeaterCoolerState() {
+        const {Characteristic} = this.hap;
+        return Characteristic.TargetHeaterCoolerState.HEAT;
+    }
+
+    setTargetHeaterCoolerState(value, callback) {
+        this.setState(this.dpProgramState, this.scheduledHeatingOn, callback);
+    }
+
+    setTargetThresholdTemperature(value, callback) {
+        this.setState(this.dpDesiredTemperature, value * this.thresholdTemperatureDivisor, err => {
+            if (err) return callback(err);
+
+            if (this.characteristicHeatingThresholdTemperature) {
+                this.characteristicHeatingThresholdTemperature.updateValue(value);
+            }
+
+            callback();
+        });
+    }
+}
+
+module.exports = SimpleThermostatAccessory;


### PR DESCRIPTION
We recently bought a new house that comes with a WiFi thermostat which controls the electric floor heating in our bathroom. The make and model of which are [Magnum MRC Remote control]( https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) which is supported by an OEM white label Tuya application. Unfortunately this app does not directly integrate with HomeKit, therefore a Homebridge plugin was required. The current version of [homebridge-tuya](https://github.com/iRayanKhan/homebridge-tuya) does not provide support for thermostat devices where custom names are provided to select specific heating schedules. In the case of our thermostat,  **AUTO** runs the regular schedule, and **MANUAL**, **FROST** or **HOLIDAY** should be used to deviate from the regular programming.

This feature aims to solve this need by splitting out the operational state of the thermostat (heating vs. idle), and the currently active heating mode (schedule vs. override), and provides the option to use the devices own enumerations for each operating state

For our specific device [MRC Remote control](https://www.magnumheating.com/products/58-1-electrical+systems/p-303-magnum+remote+control) these are the required settings:

| Function | Name in config | DP | Possible Values |
| --- | --- | --- | --- |
| Heating indicator | dpActive | 118 | "warming" (corresponds to idle) / "heating" (corresponds to heating) |
| Program status | dpProgramState | 103 | "AUTO" / "MANUAL" / "FROST" / "HOLIDAY" |
| Desired temperature | dpDesiredTemperature | 102 | temperature multiplied by 10 |
| Current temperature | dpCurrentTemperature | 106 | temperature multiplied by 10 |