### PR TITLE
Remove SimpleBlinds2 from config.schema.json and index.js

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -97,12 +97,6 @@
                     ]
                   },
                   {
-                    "title": "Simple Blinds2",
-                    "enum": [
-                      "Simple Blinds2"
-                    ]
-                  },
-                  {
                     "title": "Smart Plug w/ White and Color Lights",
                     "enum": [
                       "RGBTWOutlet"

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const GarageDoorAccessory = require('./lib/GarageDoorAccessory');
 const SimpleDimmerAccessory = require('./lib/SimpleDimmerAccessory');
 const SimpleDimmer2Accessory = require('./lib/SimpleDimmer2Accessory');
 const SimpleBlindsAccessory = require('./lib/SimpleBlindsAccessory');
-const SimpleBlinds2Accessory = require('./lib/SimpleBlinds2Accessory');
 const SimpleHeaterAccessory = require('./lib/SimpleHeaterAccessory');
 const SimpleFanAccessory = require('./lib/SimpleFanAccessory');
 const SimpleFanLightAccessory = require('./lib/SimpleFanLightAccessory');
@@ -43,7 +42,6 @@ const CLASS_DEF = {
     simpledimmer: SimpleDimmerAccessory,
     simpledimmer2: SimpleDimmer2Accessory,    
     simpleblinds: SimpleBlindsAccessory,
-    simpleblinds2: SimpleBlinds2Accessory,
     simpleheater: SimpleHeaterAccessory,
     switch: SwitchAccessory,
     fan: SimpleFanAccessory,


### PR DESCRIPTION
`SimpleBlinds2` no longer exists as an accessory type since this commit https://github.com/iRayanKhan/homebridge-tuya/commit/f85c4e3d9a1c3c138162daed68f86b5c03c8d835