### PR TITLE
Updating FanController logic to merge the setSpeed and SetActive functions

### DIFF
--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -11,9 +11,7 @@ class SimpleFanAccessory extends BaseAccessory {
 
     _registerPlatformAccessory() {
         const {Service} = this.hap;
-
         this.accessory.addService(Service.Fan, this.device.context.name);
-
         super._registerPlatformAccessory();
     }
 
@@ -27,8 +25,7 @@ class SimpleFanAccessory extends BaseAccessory {
 
         const characteristicActive = service.getCharacteristic(Characteristic.On)
             .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
+            .on('get', this.getActive.bind(this));
 
         const characteristicRotationSpeed = service.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
@@ -41,7 +38,7 @@ class SimpleFanAccessory extends BaseAccessory {
             .on('set', this.setSpeed.bind(this));
     }
 
-// State
+    // Get the Current Fan State
     getActive(callback) {
         this.getState(this.dpActive, (err, dp) => {
             if (err) return callback(err);
@@ -58,37 +55,36 @@ class SimpleFanAccessory extends BaseAccessory {
 
     setActive(value, callback) {
         const {Characteristic} = this.hap;
-		
         return this.setState(this.dpActive, value, callback);
 
         callback();
     }
 
-// Speed
+    // Get the Current Fan Speed
     getSpeed(callback) {
         this.getState(this.dpRotationSpeed, (err, dp) => {
             if (err) return callback(err);
-
             callback(null, this._getSpeed(dp));
         });
     }
 
     _getSpeed(dp) {
         const {Characteristic} = this.hap;
-//		console.log("_getSpeed = " + dp);
         return dp;
     }
 
+    // Set the new fan speed
     setSpeed(value, callback) {
-        const {Characteristic} = this.hap;
-        if (value == 0) {
-        	return this.setState(this.dpActive, false, callback);
-        } else {
-        	return this.setState(this.dpRotationSpeed, value.toString(), callback);
-        }
-
-        callback();
-    }	
+      const {Characteristic} = this.hap;
+      if (value === 0) {
+        // This will turn off the fan speed if it is set to be 0.
+        return this.setState(this.dpActive, false, callback);
+      } else {
+        // This uses the multistate set command to send the fan on and speed request in one call.
+        return this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: value.toString()}, callback);
+      }
+      callback();
+    }
 
 }
 

--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -17,46 +17,73 @@ class SimpleFanAccessory extends BaseAccessory {
 
     _registerCharacteristics(dps) {
         const {Service, Characteristic} = this.hap;
-        const service = this.accessory.getService(Service.Fan);
-        this._checkServiceName(service, this.device.context.name);
+        const serviceFan = this.accessory.getService(Service.Fan);
+        this._checkServiceName(serviceFan, this.device.context.name);
+        this.dpFanOn = this._getCustomDP(this.device.context.dpFanOn) || '1';
+        this.dpRotationSpeed = this._getCustomDP(this.device.context.RotationSpeed) || '3';
+        this.maxSpeed = parseInt(this.device.context.maxSpeed) || 3;
+        // This variable is here so that we can set the fans to turn onto speed one instead of 3 on start.
+        this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
+        // This variable is here as a workaround to allow for the on/off function to work.
+        this.fanCurrentSpeed = 0;
 
-        this.dpActive = this._getCustomDP(this.device.context.dpActive) || '1';
-        this.dpRotationSpeed = this._getCustomDP(this.device.context.dpRotationSpeed) || '3';
+        const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
+            .updateValue(this._getFanOn(dps[this.dpFanOn]))
+            .on('get', this.getFanOn.bind(this))
+            .on('set', this.setFanOn.bind(this));
 
-        const characteristicActive = service.getCharacteristic(Characteristic.On)
-            .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this));
-
-        const characteristicRotationSpeed = service.getCharacteristic(Characteristic.RotationSpeed)
+        const characteristicRotationSpeed = serviceFan.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
                 minValue: 0,
-                maxValue: 3,
+                maxValue: this.maxSpeed,
                 minStep: 1
             })
             .updateValue(this._getSpeed(dps[this.dpRotationSpeed]))
             .on('get', this.getSpeed.bind(this))
             .on('set', this.setSpeed.bind(this));
-    }
 
-    // Get the Current Fan State
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
-            if (err) return callback(err);
+        this.device.on('change', (changes, state) => {
 
-            callback(null, this._getActive(dp));
+            if (changes.hasOwnProperty(this.dpFanOn) && characteristicFanOn.value !== changes[this.dpFanOn])
+                characteristicFanOn.updateValue(changes[this.dpFanOn]);
+
+            if (changes.hasOwnProperty(this.dpRotationSpeed) && characteristicRotationSpeed.value !== changes[this.dpRotationSpeed])
+                characteristicRotationSpeed.updateValue(changes[this.dpRotationSpeed]);
+
+            console.log('[Tuya] SimpleFan changed: ' + JSON.stringify(state));
         });
     }
 
-    _getActive(dp) {
-        const {Characteristic} = this.hap;
+    /*************************** FAN ***************************/
+    // Get the Current Fan State
+    getFanOn(callback) {
+        this.getState(this.dpFanOn, (err, dp) => {
+            if (err) return callback(err);
+            callback(null, this._getFanOn(dp));
+        });
+    }
 
+    _getFanOn(dp) {
+        const {Characteristic} = this.hap;
         return dp;
     }
 
-    setActive(value, callback) {
+    setFanOn(value, callback) {
         const {Characteristic} = this.hap;
-        return this.setState(this.dpActive, value, callback);
-
+        // This uses the multistate set command to send the fan on and speed request in one call.
+        if (value == false ) {
+          this.fanCurrentSpeed = 0;
+          // This will turn off the fan speed if it is set to be 0.
+          return this.setState(this.dpFanOn, false, callback);
+        } else {
+          if (this.fanCurrentSpeed === 0) {
+            // The current fanDefaultSpeed Variable is there to have the fan set to a sensible default if turned on.
+            return this.setMultiState({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+          } else {
+            // The current fanCurrentSpeed Variable is there to ensure the fan speed doesn't change if the fan is already on.
+            return this.setMultiState({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+          }
+        }
         callback();
     }
 
@@ -77,15 +104,16 @@ class SimpleFanAccessory extends BaseAccessory {
     setSpeed(value, callback) {
       const {Characteristic} = this.hap;
       if (value === 0) {
-        // This will turn off the fan speed if it is set to be 0.
-        return this.setState(this.dpActive, false, callback);
+        // This is to set the fan speed variable to be 1 when the fan is off.
+        return this.setMultiState({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
       } else {
+        // This is to set the fan speed variable to match the current speed.
+        this.fanCurrentSpeed = value;
         // This uses the multistate set command to send the fan on and speed request in one call.
-        return this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: value.toString()}, callback);
+        return this.setMultiState({[this.dpFanOn]: true, [this.dpRotationSpeed]: value.toString()}, callback);
       }
       callback();
     }
-
 }
 
 module.exports = SimpleFanAccessory;

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -22,18 +22,22 @@ class SimpleFanLightAccessory extends BaseAccessory {
         const serviceLightbulb = this.accessory.getService(Service.Lightbulb);
         this._checkServiceName(serviceFan, this.device.context.name);
         this._checkServiceName(serviceLightbulb, this.device.context.name + " Light");
-
-        this.dpActive = this._getCustomDP(this.device.context.dpActive) || '1';
+        this.dpFanOn = this._getCustomDP(this.device.context.dpFanOn) || '1';
         this.dpRotationSpeed = this._getCustomDP(this.device.context.RotationSpeed) || '3';
         this.dpLightOn = this._getCustomDP(this.device.context.dpLightOn) || '9';
         this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || '10';
         this.useLight = this._coerceBoolean(this.device.context.useLight, true);
-        this.useBrightness = this._coerceBoolean(this.device.context.useBrightness, true);
+        this.useBrightness = this._coerceBoolean(this.device.context.useBrightness, false);
         this.maxSpeed = parseInt(this.device.context.maxSpeed) || 3;
+        // This variable is here so that we can set the fans to turn onto speed one instead of 3 on start.
+        this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
+        // This variable is here as a workaround to allow for the on/off function to work.
+        this.fanCurrentSpeed = 0;
 
-        const characteristicActive = serviceFan.getCharacteristic(Characteristic.On)
-            .updateValue(this._getActive(dps[this.dpActive]))
-            .on('get', this.getActive.bind(this))
+        const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
+            .updateValue(this._getFanOn(dps[this.dpFanOn]))
+            .on('get', this.getFanOn.bind(this))
+            .on('set', this.setFanOn.bind(this));
 
         const characteristicRotationSpeed = serviceFan.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
@@ -45,10 +49,10 @@ class SimpleFanLightAccessory extends BaseAccessory {
             .on('get', this.getSpeed.bind(this))
             .on('set', this.setSpeed.bind(this));
 
-        let characterLightOn;
+        let characteristicLightOn;
         let characteristicBrightness;
         if (this.useLight) {
-            characterLightOn = serviceLightbulb.getCharacteristic(Characteristic.On)
+            characteristicLightOn = serviceLightbulb.getCharacteristic(Characteristic.On)
                 .updateValue(this._getLightOn(dps[this.dpLightOn]))
                 .on('get', this.getLightOn.bind(this))
                 .on('set', this.setLightOn.bind(this));
@@ -67,11 +71,15 @@ class SimpleFanLightAccessory extends BaseAccessory {
         }
 
         this.device.on('change', (changes, state) => {
+
+            if (changes.hasOwnProperty(this.dpFanOn) && characteristicFanOn.value !== changes[this.dpFanOn])
+                characteristicFanOn.updateValue(changes[this.dpFanOn]);
+
             if (changes.hasOwnProperty(this.dpRotationSpeed) && characteristicRotationSpeed.value !== changes[this.dpRotationSpeed])
                 characteristicRotationSpeed.updateValue(changes[this.dpRotationSpeed]);
 
-            if (changes.hasOwnProperty(this.dpLightOn) && characterLightOn && characterLightOn.value !== changes[this.dpLightOn])
-                characterLightOn.updateValue(changes[this.dpLightOn]);
+            if (changes.hasOwnProperty(this.dpLightOn) && characteristicLightOn && characteristicLightOn.value !== changes[this.dpLightOn])
+                characteristicLightOn.updateValue(changes[this.dpLightOn]);
 
             if (changes.hasOwnProperty(this.dpBrightness) && characteristicBrightness && characteristicBrightness.value !== changes[this.dpBrightness])
                 characteristicBrightness.updateValue(changes[this.dpBrightness]);
@@ -82,16 +90,35 @@ class SimpleFanLightAccessory extends BaseAccessory {
 
     /*************************** FAN ***************************/
     // Get the Current Fan State
-    getActive(callback) {
-        this.getState(this.dpActive, (err, dp) => {
+    getFanOn(callback) {
+        this.getState(this.dpFanOn, (err, dp) => {
             if (err) return callback(err);
-            callback(null, this._getActive(dp));
+            callback(null, this._getFanOn(dp));
         });
     }
 
-    _getActive(dp) {
+    _getFanOn(dp) {
         const {Characteristic} = this.hap;
         return dp;
+    }
+
+    setFanOn(value, callback) {
+        const {Characteristic} = this.hap;
+        // This uses the multistate set command to send the fan on and speed request in one call.
+        if (value == false ) {
+          this.fanCurrentSpeed = 0;
+          // This will turn off the fan speed if it is set to be 0.
+          return this.setState(this.dpFanOn, false, callback);
+        } else {
+          if (this.fanCurrentSpeed === 0) {
+            // The current fanDefaultSpeed Variable is there to have the fan set to a sensible default if turned on.
+            return this.setMultiState({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+          } else {
+            // The current fanCurrentSpeed Variable is there to ensure the fan speed doesn't change if the fan is already on.
+            return this.setMultiState({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+          }
+        }
+        callback();
     }
 
     // Get the Current Fan Speed
@@ -111,11 +138,13 @@ class SimpleFanLightAccessory extends BaseAccessory {
     setSpeed(value, callback) {
       const {Characteristic} = this.hap;
       if (value === 0) {
-        // This will turn off the fan speed if it is set to be 0.
-        return this.setState(this.dpActive, false, callback);
+        // This is to set the fan speed variable to be 1 when the fan is off.
+        return this.setMultiState({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
       } else {
+        // This is to set the fan speed variable to match the current speed.
+        this.fanCurrentSpeed = value;
         // This uses the multistate set command to send the fan on and speed request in one call.
-        return this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: value.toString()}, callback);
+        return this.setMultiState({[this.dpFanOn]: true, [this.dpRotationSpeed]: value.toString()}, callback);
       }
       callback();
     }

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -11,10 +11,8 @@ class SimpleFanLightAccessory extends BaseAccessory {
 
     _registerPlatformAccessory() {
         const {Service} = this.hap;
-
         this.accessory.addService(Service.Fan, this.device.context.name);
         this.accessory.addService(Service.Lightbulb, this.device.context.name + " Light");
-
         super._registerPlatformAccessory();
     }
 
@@ -31,12 +29,11 @@ class SimpleFanLightAccessory extends BaseAccessory {
         this.dpBrightness = this._getCustomDP(this.device.context.dpBrightness) || '10';
         this.useLight = this._coerceBoolean(this.device.context.useLight, true);
         this.useBrightness = this._coerceBoolean(this.device.context.useBrightness, true);
-        this.maxSpeed = parseInt(this.device.context.maxSpeed) || 4;
+        this.maxSpeed = parseInt(this.device.context.maxSpeed) || 3;
 
         const characteristicActive = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getActive(dps[this.dpActive]))
             .on('get', this.getActive.bind(this))
-            .on('set', this.setActive.bind(this));
 
         const characteristicRotationSpeed = serviceFan.getCharacteristic(Characteristic.RotationSpeed)
             .setProps({
@@ -70,9 +67,6 @@ class SimpleFanLightAccessory extends BaseAccessory {
         }
 
         this.device.on('change', (changes, state) => {
-            if (changes.hasOwnProperty(this.dpActive) && characteristicActive.value !== changes[this.dpActive])
-                characteristicActive.updateValue(changes[this.dpActive]);
-
             if (changes.hasOwnProperty(this.dpRotationSpeed) && characteristicRotationSpeed.value !== changes[this.dpRotationSpeed])
                 characteristicRotationSpeed.updateValue(changes[this.dpRotationSpeed]);
 
@@ -86,100 +80,82 @@ class SimpleFanLightAccessory extends BaseAccessory {
         });
     }
 
-/*************************** FAN ***************************/
-// Fan State
+    /*************************** FAN ***************************/
+    // Get the Current Fan State
     getActive(callback) {
         this.getState(this.dpActive, (err, dp) => {
             if (err) return callback(err);
-
             callback(null, this._getActive(dp));
         });
     }
 
     _getActive(dp) {
         const {Characteristic} = this.hap;
-
         return dp;
     }
 
-    setActive(value, callback) {
-        const {Characteristic} = this.hap;
-		
-        return this.setState(this.dpActive, value, callback);
-
-        callback();
-    }
-
-// Fan Speed
+    // Get the Current Fan Speed
     getSpeed(callback) {
         this.getState(this.dpRotationSpeed, (err, dp) => {
             if (err) return callback(err);
-
             callback(null, this._getSpeed(dp));
         });
     }
 
     _getSpeed(dp) {
         const {Characteristic} = this.hap;
-//		console.log("_getSpeed = " + dp);
         return dp;
     }
 
+    // Set the new fan speed
     setSpeed(value, callback) {
-        const {Characteristic} = this.hap;
-        if (value == 0) {
-        	return this.setState(this.dpActive, false, callback);
-        } else {
-        	return this.setState(this.dpRotationSpeed, value.toString(), callback);
-        }
-
-        callback();
+      const {Characteristic} = this.hap;
+      if (value === 0) {
+        // This will turn off the fan speed if it is set to be 0.
+        return this.setState(this.dpActive, false, callback);
+      } else {
+        // This uses the multistate set command to send the fan on and speed request in one call.
+        return this.setMultiState({[this.dpActive]: true, [this.dpRotationSpeed]: value.toString()}, callback);
+      }
+      callback();
     }
-    
-/*************************** LIGHT ***************************/
-// Lightbulb State
+
+    /*************************** LIGHT ***************************/
+    //Lightbulb State
     getLightOn(callback) {
         this.getState(this.dpLightOn, (err, dp) => {
             if (err) return callback(err);
-
             callback(null, this._getLightOn(dp));
         });
     }
 
     _getLightOn(dp) {
         const {Characteristic} = this.hap;
-
         return dp;
     }
 
     setLightOn(value, callback) {
         const {Characteristic} = this.hap;
-		
         return this.setState(this.dpLightOn, value, callback);
-
         callback();
     }
-    
-// Lightbulb Brightness
+
+    //Lightbulb Brightness
     getBrightness(callback) {
         this.getState(this.dpBrightness, (err, dp) => {
             if (err) return callback(err);
-
             callback(null, this._getBrightness(dp));
         });
     }
-    
+
     _getBrightness(dp) {
         const {Characteristic} = this.hap;
-//		console.log("_getBrightness = " + dp);
         return dp;
     }
 
     setBrightness(value, callback) {
         const {Characteristic} = this.hap;
-//        console.log("setBrightness - Raw value = " + value);
         return this.setState(this.dpBrightness, value, callback);
-
         callback();
     }
 }


### PR DESCRIPTION
Removing the standalone setActive function that turns the fan on and instead sing the SetMultiState function to turn the fan on when it sets the speed.

Some Fan Controllers like the DETA 3 Speed Fan Controller with Light default to a particular speed when it is turned on. The existing logic sets the fan to active and then sets the speed. This causes a clash as the response from the switch turning the fan on will sets the speed to 3 and override the subsequent update speed call. This change fixes that by ensuring that only one call is made to turn the fan on and set the rotation speed.