### PR TITLE
Allow setting brightness values via config

### DIFF
--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -59,9 +59,9 @@ class SimpleFanLightAccessory extends BaseAccessory {
             if (this.useBrightness) {
                 characteristicBrightness = serviceLightbulb.getCharacteristic(Characteristic.Brightness)
                     .setProps({
-                        minValue: 0,
-                        maxValue: 1000,
-                        minStep: 100
+                        minValue: this.device.context.minBrightness || 0,
+                        maxValue: this.device.context.maxBrightness || 1000,
+                        minStep: this.device.context.brightnessStep || 10
                     })
                     .updateValue(this.convertBrightnessFromTuyaToHomeKit(dps[this.dpBrightness]))
                     .on('get', this.getBrightness.bind(this))
@@ -162,25 +162,19 @@ class SimpleFanLightAccessory extends BaseAccessory {
     
 // Lightbulb Brightness
     getBrightness(callback) {
-        this.getState(this.dpBrightness, (err, dp) => {
-            if (err) return callback(err);
-
-            callback(null, this._getBrightness(dp));
-        });
+	    if (this.useBrightness) {
+		    callback(null, this.convertBrightnessFromTuyaToHomeKit(this.device.state[this.dpBrightness]));
+	    } else {
+		    if (this.device.state[this.dpLightOn]) {
+			    callback(null, 0);
+		    } else {
+			    callback(null, this.device.context.maxBrightness || 1000);
+		    }
+	    }
     }
     
-    _getBrightness(dp) {
-        const {Characteristic} = this.hap;
-//		console.log("_getBrightness = " + dp);
-        return dp;
-    }
-
     setBrightness(value, callback) {
-        const {Characteristic} = this.hap;
-//        console.log("setBrightness - Raw value = " + value);
-        return this.setState(this.dpBrightness, value, callback);
-
-        callback();
+        this.setState(this.dpBrightness, this.convertBrightnessFromHomeKitToTuya(value), callback);
     }
 }
 


### PR DESCRIPTION
This takes in minBrightness, maxBrightness and brightnessStep from the config file.

By using the standard convertBrightnessFromHomeKitToTuya function it also respects the value of scaleBrightness if it is set.

This allows the same accessory code to be used for both the Arlec Grid Connect Ceiling Fan and the Deta Grid Connect Smart Fan Speed Controller.