### PR TITLE
Add useStrings config setting to make .toString() conversion optional

### DIFF
--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -26,6 +26,8 @@ class SimpleFanAccessory extends BaseAccessory {
         this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
         // This variable is here as a workaround to allow for the on/off function to work.
         this.fanCurrentSpeed = 0;
+        // Add setting to use .toString() on return values or not.
+        this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
 
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
@@ -78,10 +80,18 @@ class SimpleFanAccessory extends BaseAccessory {
         } else {
           if (this.fanCurrentSpeed === 0) {
             // The current fanDefaultSpeed Variable is there to have the fan set to a sensible default if turned on.
-            return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+            if (this.useStrings) {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+            } else {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+            }
           } else {
             // The current fanCurrentSpeed Variable is there to ensure the fan speed doesn't change if the fan is already on.
-            return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+            if (this.useStrings) {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+            } else {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed}, callback);
+            }
           }
         }
         callback();
@@ -100,12 +110,20 @@ class SimpleFanAccessory extends BaseAccessory {
       const {Characteristic} = this.hap;
       if (value === 0) {
         // This is to set the fan speed variable to be 1 when the fan is off.
-        return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+        if (this.useStrings) {
+            return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+        } else {
+            return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+        }
       } else {
         // This is to set the fan speed variable to match the current speed.
         this.fanCurrentSpeed = this.convertRotationSpeedFromHomeKitToTuya(value);
         // This uses the multistatelegacy set command to send the fan on and speed request in one call.
-        return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
+        if (this.useStrings) {
+            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
+        } else {
+            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);            
+        }
       }
       callback();
     }

--- a/lib/SimpleFanLightAccessory.js
+++ b/lib/SimpleFanLightAccessory.js
@@ -33,6 +33,8 @@ class SimpleFanLightAccessory extends BaseAccessory {
         this.fanDefaultSpeed = parseInt(this.device.context.fanDefaultSpeed) || 1;
         // This variable is here as a workaround to allow for the on/off function to work.
         this.fanCurrentSpeed = 0;
+        // Add setting to use .toString() on return values or not.
+        this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
 
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
@@ -112,10 +114,18 @@ class SimpleFanLightAccessory extends BaseAccessory {
         } else {
           if (this.fanCurrentSpeed === 0) {
             // The current fanDefaultSpeed Variable is there to have the fan set to a sensible default if turned on.
-            return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+            if (this.useStrings) {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+            } else {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+            }
           } else {
             // The current fanCurrentSpeed Variable is there to ensure the fan speed doesn't change if the fan is already on.
-            return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+            if (this.useStrings) {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed.toString()}, callback);
+            } else {
+                return this.setMultiStateLegacy({[this.dpFanOn]: value, [this.dpRotationSpeed]: this.fanCurrentSpeed}, callback);
+            }
           }
         }
         callback();
@@ -134,12 +144,20 @@ class SimpleFanLightAccessory extends BaseAccessory {
       const {Characteristic} = this.hap;
       if (value === 0) {
         // This is to set the fan speed variable to be 1 when the fan is off.
-        return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+        if (this.useStrings) {
+            return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
+        } else {
+            return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed}, callback);
+        }
       } else {
         // This is to set the fan speed variable to match the current speed.
         this.fanCurrentSpeed = this.convertRotationSpeedFromHomeKitToTuya(value);
         // This uses the multistatelegacy set command to send the fan on and speed request in one call.
-        return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
+        if (this.useStrings) {
+            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
+        } else {
+            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);            
+        }
       }
       callback();
     }


### PR DESCRIPTION
Not sure exactly what makes this environmentally dependent, but my fan controllers don't speak string.

It's not the most elegant solution, so I'm open to alternatives. But it does work, and defaults to using .toString() if that's the more commonly used form.