### PR TITLE
Make MultiState requests optional on Fan accessory

### DIFF
--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -28,6 +28,8 @@ class SimpleFanAccessory extends BaseAccessory {
         this.fanCurrentSpeed = 0;
         // Add setting to use .toString() on return values or not.
         this.useStrings = this._coerceBoolean(this.device.context.useStrings, true);
+        // Whether multiple state requests should be sent to device
+        this.useMultiState = this._coerceBoolean(this.device.context.useMultiState, true);
 
         const characteristicFanOn = serviceFan.getCharacteristic(Characteristic.On)
             .updateValue(this._getFanOn(dps[this.dpFanOn]))
@@ -108,7 +110,7 @@ class SimpleFanAccessory extends BaseAccessory {
     // Set the new fan speed
     setSpeed(value, callback) {
       const {Characteristic} = this.hap;
-      if (value === 0) {
+      if (value === 0 && this.useMultiState) {
         // This is to set the fan speed variable to be 1 when the fan is off.
         if (this.useStrings) {
             return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
@@ -121,8 +123,10 @@ class SimpleFanAccessory extends BaseAccessory {
         // This uses the multistatelegacy set command to send the fan on and speed request in one call.
         if (this.useStrings) {
             return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
-        } else {
+        } else if (this.useMultiState) {
             return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);            
+        } else {
+            return this.setState(this.dpRotationSpeed, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
         }
       }
       callback();

--- a/lib/SimpleFanAccessory.js
+++ b/lib/SimpleFanAccessory.js
@@ -75,7 +75,10 @@ class SimpleFanAccessory extends BaseAccessory {
     setFanOn(value, callback) {
         const {Characteristic} = this.hap;
         // This uses the multistate set command to send the fan on and speed request in one call.
-        if (value == false ) {
+        
+        if (!this.useMultiState) {
+          return this.setState(this.dpFanOn, value, callback);
+        } else if (value == false ) {
           this.fanCurrentSpeed = 0;
           // This will turn off the fan speed if it is set to be 0.
           return this.setState(this.dpFanOn, false, callback);
@@ -110,7 +113,9 @@ class SimpleFanAccessory extends BaseAccessory {
     // Set the new fan speed
     setSpeed(value, callback) {
       const {Characteristic} = this.hap;
-      if (value === 0 && this.useMultiState) {
+      if (!this.useMultiState) {
+          return this.setState(this.dpRotationSpeed, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
+      } else if (value === 0) {
         // This is to set the fan speed variable to be 1 when the fan is off.
         if (this.useStrings) {
             return this.setMultiStateLegacy({[this.dpFanOn]: false, [this.dpRotationSpeed]: this.fanDefaultSpeed.toString()}, callback);
@@ -123,10 +128,8 @@ class SimpleFanAccessory extends BaseAccessory {
         // This uses the multistatelegacy set command to send the fan on and speed request in one call.
         if (this.useStrings) {
             return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value).toString()}, callback);
-        } else if (this.useMultiState) {
-            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);            
         } else {
-            return this.setState(this.dpRotationSpeed, this.convertRotationSpeedFromHomeKitToTuya(value), callback);
+            return this.setMultiStateLegacy({[this.dpFanOn]: true, [this.dpRotationSpeed]: this.convertRotationSpeedFromHomeKitToTuya(value)}, callback);            
         }
       }
       callback();


### PR DESCRIPTION
With the recent changes, I can expose a `SimpleDimmerAccessory` as a `Fan` with a small patch thereby closing the need for #405 

Sample config:
```json
{
    "type": "Fan",
    "name": "Fan",
    "maxSpeed": 100,
    "fanDefaultSpeed": 0,
    "dpRotationSpeed": 2,
    "useStrings": false,
    "useMultiState": false
}
```