### PR TITLE
SimpleHeater: use IDLE state to properly show up in HomeKit, add offset for currentTemperature, fix targetTemperatureDivisor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -454,6 +454,13 @@
                   "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
                 }
               },
+              "temperatureOffset": {
+                "type": "integer",
+                "placeholder": "0",
+                "condition": {
+                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
+                }
+              },
               "dpAction": {
                 "type": "integer",
                 "placeholder": "1",

--- a/config.schema.json
+++ b/config.schema.json
@@ -454,13 +454,6 @@
                   "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
                 }
               },
-              "targetTemperatureDivisor": {
-                "type": "integer",
-                "placeholder": "1",
-                "condition": {
-                  "functionBody": "return model.devices && model.devices[arrayIndices] && ['SimpleHeater'].includes(model.devices[arrayIndices].type);"
-                }
-              },
               "dpAction": {
                 "type": "integer",
                 "placeholder": "1",

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -28,6 +28,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
         this.dpCurrentTemperature = this._getCustomDP(this.device.context.dpCurrentTemperature) || '3';
         this.temperatureDivisor = parseInt(this.device.context.temperatureDivisor) || 1;
         this.thresholdTemperatureDivisor = parseInt(this.device.context.thresholdTemperatureDivisor) || 1;
+        this.temperatureOffset = parseInt(this.device.context.temperatureOffset) || 0;
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.dpActive]))
@@ -146,7 +147,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
     }
 
     setTargetThresholdTemperature(value, callback) {
-        this.setState(this.dpDesiredTemperature, value * this.thresholdTemperatureDivisor, err => {
+        this.setState(this.dpDesiredTemperature, (value - this.temperatureOffset) * this.thresholdTemperatureDivisor, err => {
             if (err) return callback(err);
 
             if (this.characteristicHeatingThresholdTemperature) {
@@ -155,6 +156,10 @@ class SimpleHeaterAccessory extends BaseAccessory {
 
             callback();
         });
+    }
+
+    _getDividedState(dp, divisor) {
+        return ((parseFloat(dp) + this.temperatureOffset) / divisor) || 0;
     }
 }
 

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -27,7 +27,6 @@ class SimpleHeaterAccessory extends BaseAccessory {
         this.dpCurrentTemperature = this._getCustomDP(this.device.context.dpCurrentTemperature) || '3';
         this.temperatureDivisor = parseInt(this.device.context.temperatureDivisor) || 1;
         this.thresholdTemperatureDivisor = parseInt(this.device.context.thresholdTemperatureDivisor) || 1;
-        this.targetTemperatureDivisor = parseInt(this.device.context.targetTemperatureDivisor) || 1;
 
         const characteristicActive = service.getCharacteristic(Characteristic.Active)
             .updateValue(this._getActive(dps[this.dpActive]))
@@ -75,7 +74,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
 
             if (changes.hasOwnProperty(this.dpDesiredTemperature)) {
                 if (characteristicHeatingThresholdTemperature.value !== changes[this.dpDesiredTemperature])
-                    characteristicHeatingThresholdTemperature.updateValue(changes[this.dpDesiredTemperature * this.targetTemperatureDivisor]);
+                    characteristicHeatingThresholdTemperature.updateValue(this._getDividedState(changes[this.dpDesiredTemperature], this.thresholdTemperatureDivisor));
             }
 
             if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor));

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -7,6 +7,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
 
     constructor(...props) {
         super(...props);
+        this.currentHeaterCoolerState = 0;
     }
 
     _registerPlatformAccessory() {
@@ -33,7 +34,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
             .on('get', this.getActive.bind(this))
             .on('set', this.setActive.bind(this));
 
-        service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
+        const characteristicCurrentHeaterCoolerState = service.getCharacteristic(Characteristic.CurrentHeaterCoolerState)
             .updateValue(this._getCurrentHeaterCoolerState(dps))
             .on('get', this.getCurrentHeaterCoolerState.bind(this));
 
@@ -79,6 +80,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
 
             if (changes.hasOwnProperty(this.dpCurrentTemperature) && characteristicCurrentTemperature.value !== changes[this.dpCurrentTemperature]) characteristicCurrentTemperature.updateValue(this._getDividedState(changes[this.dpCurrentTemperature], this.temperatureDivisor));
 
+            characteristicCurrentHeaterCoolerState.updateValue(this._getCurrentHeaterCoolerState(state));
             this.log.info('SimpleHeater changed: ' + JSON.stringify(state));
         });
     }
@@ -112,16 +114,22 @@ class SimpleHeaterAccessory extends BaseAccessory {
     }
 
     getCurrentHeaterCoolerState(callback) {
-        this.getState([this.dpActive], (err, dps) => {
-            if (err) return callback(err);
-
-            callback(null, this._getCurrentHeaterCoolerState(dps));
-        });
+        callback(null, this.currentHeaterCoolerState);
     }
 
     _getCurrentHeaterCoolerState(dps) {
         const {Characteristic} = this.hap;
-        return dps[this.dpActive] ? Characteristic.CurrentHeaterCoolerState.HEATING : Characteristic.CurrentHeaterCoolerState.INACTIVE;
+        if (dps[this.dpActive]) {
+            if (dps[this.dpCurrentTemperature] <  dps[this.dpDesiredTemperature]) {
+                this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.HEATING;
+            }
+            if (dps[this.dpCurrentTemperature] >  dps[this.dpDesiredTemperature]) {
+                this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.IDLE;
+            }
+         } else {
+             this.currentHeaterCoolerState = Characteristic.CurrentHeaterCoolerState.INACTIVE;
+         };
+        return this.currentHeaterCoolerState;
     }
 
     getTargetHeaterCoolerState(callback) {

--- a/lib/SimpleHeaterAccessory.js
+++ b/lib/SimpleHeaterAccessory.js
@@ -159,7 +159,7 @@ class SimpleHeaterAccessory extends BaseAccessory {
     }
 
     _getDividedState(dp, divisor) {
-        return ((parseFloat(dp) + this.temperatureOffset) / divisor) || 0;
+        return ((parseFloat(dp) / divisor) + this.temperatureOffset) || 0;
     }
 }
 


### PR DESCRIPTION
SimpleHeater:

a) doesn't properly reflect the state of the Heater, because it only uses HEATING and INACTIVE.
If a Heater is above its target temerature, the heater ist still active, but in IDLE mode.

b) Temparature measurement of a heater may be off by some amount. Adding an offset will fix this

c) In SimpleHeater there's no need for targetTemperatureDivisor. Instead _getDividedState() is the way to do.
This fixes #467. Further _getDividedState() is used an essential for the temperature offset.

This PR adds these three issues.



