### PR TITLE
Customizable discover timeout

### DIFF
--- a/config-example.MD
+++ b/config-example.MD
@@ -15,6 +15,7 @@ The configuration parameters to enable your devices would need to be added to `p
         /* The block you need to enable this plugin */
         {
             "platform": "TuyaLan",
+            "discoverTimeout": 60000,
             "devices": [
                 /* The block you need for each device */
                 {
@@ -33,7 +34,7 @@ The configuration parameters to enable your devices would need to be added to `p
     ...
 }
 ```
-#### Parameters
+#### Device parameters
 * `name` (required) is anything you'd like to use to identify this device. You can always change the name from within the Home app.
 * `type` (required) is a case-insensitive identifier that lets the plugin know how to handle your device. Find your device `type` on the [Supported Device Type List](https://github.com/iRayanKhan/homebridge-tuya/wiki/Supported-Device-Types) page.
 * `manufacturer` and `model` are anything you like; the purpose of them is to help you identify the device.
@@ -41,3 +42,6 @@ The configuration parameters to enable your devices would need to be added to `p
 * `ip` needs to be added **_only_** if you face discovery issues. See [Common Problems](https://github.com/iRayanKhan/homebridge-tuya/wiki/Common-Problems) for more details.   
 
 > To find out which `id` belongs to which device, open the Tuya Smart app and check the `Device Information` by tapping the configuration icon of your devices; it is almost always a tiny icon on the top-right.
+
+#### Other parameters
+* `discoverTimeout` (optional) is the time period (millisecond) the plugin should spend for device auto-discovery. If unspecified, the default value is 60000.

--- a/config.schema.json
+++ b/config.schema.json
@@ -7,6 +7,14 @@
     "schema": {
       "type": "object",
       "properties": {
+        "discoveryTimeout": {
+          "title": "Device IP auto-discovery timeout",
+          "type": "integer",
+          "minimum": 0,
+          "placeholder": "Timeout (millisecond) for device IP address discovery",
+          "default": 60000,
+          "required": false
+        },
         "devices": {
           "type": "array",
           "orderable": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -7,7 +7,7 @@
     "schema": {
       "type": "object",
       "properties": {
-        "discoveryTimeout": {
+        "discoverTimeout": {
           "title": "Device IP auto-discovery timeout",
           "type": "integer",
           "minimum": 0,

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const OilDiffuserAccessory = require('./lib/OilDiffuserAccessory');
 
 const PLUGIN_NAME = 'homebridge-tuya';
 const PLATFORM_NAME = 'TuyaLan';
+const DEFAULT_DISCOVER_TIMEOUT = 60000;
 
 const CLASS_DEF = {
     outlet: OutletAccessory,
@@ -152,7 +153,7 @@ class TuyaLan {
                     this.log.warn('Failed to discover %s (%s) in time but will keep looking.', devices[deviceId].name, deviceId);
                 }
             });
-        }, 60000);
+        }, this.config.discoverTimeout ?? DEFAULT_DISCOVER_TIMEOUT);
     }
 
     registerPlatformAccessories(platformAccessories) {


### PR DESCRIPTION
Allow customizable timeout for device IP discovery

This configuration should be useful in the scenario where the accessories are assigned fixed IP.