### PR TITLE
Saturation assignment fix in RGBTWLightAccessory.js

### DIFF
--- a/lib/RGBTWLightAccessory.js
+++ b/lib/RGBTWLightAccessory.js
@@ -126,7 +126,7 @@ class RGBTWLightAccessory extends BaseAccessory {
                         if (oldColor.b !== newColor.b) characteristicBrightness.updateValue(newColor.b);
                         if (oldColor.h !== newColor.h) characteristicHue.updateValue(newColor.h);
 
-                        if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.h);
+                        if (oldColor.s !== newColor.s) characteristicSaturation.updateValue(newColor.s);
 
                         if (characteristicColorTemperature.value !== 0) characteristicColorTemperature.updateValue(0);
 


### PR DESCRIPTION
Correctly assign saturation value with newColor.s instead of newColor.h

This fixes error like this:

```
[23/09/2024, 01:58:19] [homebridge-tuya] This plugin generated a warning from the characteristic 'Saturation': characteristic was supplied illegal value: number 300 exceeded maximum of 100. See https://homebridge.io/w/JtMGR for more info.
[23/09/2024, 01:58:19] [homebridge-tuya] Error: 
    at Saturation.Characteristic.characteristicWarning (/var/lib/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:3016:105)
    at Saturation.Characteristic.validateUserInput (/var/lib/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2932:14)
    at Saturation.Characteristic.updateValue (/var/lib/homebridge/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2333:20)
    at TuyaAccessory.<anonymous> (/var/lib/homebridge/node_modules/homebridge-tuya/lib/RGBTWLightAccessory.js:129:81)
    at TuyaAccessory.emit (node:events:518:28)
    at TuyaAccessory._change (/var/lib/homebridge/node_modules/homebridge-tuya/lib/TuyaAccessory.js:562:18)
    at TuyaAccessory._msgHandler_3_4 (/var/lib/homebridge/node_modules/homebridge-tuya/lib/TuyaAccessory.js:475:30)
    at /var/lib/homebridge/node_modules/homebridge-tuya/node_modules/async/dist/async.js:4018:13
    at Object.process (/var/lib/homebridge/node_modules/homebridge-tuya/node_modules/async/dist/async.js:1681:21)
    at /var/lib/homebridge/node_modules/homebridge-tuya/node_modules/async/dist/async.js:1533:23
```

